### PR TITLE
Implement Go-based Selene parser and CLI

### DIFF
--- a/cmd/selene/main.go
+++ b/cmd/selene/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"selenelang/internal/lexer"
+	"selenelang/internal/parser"
+	"selenelang/internal/token"
+)
+
+func main() {
+	dumpTokens := flag.Bool("tokens", false, "print the token stream")
+	flag.Parse()
+
+	if flag.NArg() == 0 {
+		fmt.Fprintln(os.Stderr, "usage: selene [--tokens] <file>")
+		os.Exit(1)
+	}
+
+	filename := flag.Arg(0)
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read %s: %v\n", filename, err)
+		os.Exit(1)
+	}
+
+	l := lexer.New(string(content))
+	if *dumpTokens {
+		for tok := l.NextToken(); tok.Type != token.EOF; tok = l.NextToken() {
+			fmt.Printf("%s\t%q\n", tok.Type, tok.Literal)
+		}
+		return
+	}
+
+	l = lexer.New(string(content))
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if errs := p.Errors(); len(errs) > 0 {
+		for _, e := range errs {
+			fmt.Fprintln(os.Stderr, "parse error:", e)
+		}
+		os.Exit(1)
+	}
+
+	fmt.Printf("Parsed %s successfully (%d top-level items).\n", filename, len(program.Items))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module selenelang
+
+go 1.24.3

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -1,0 +1,466 @@
+package ast
+
+import "selenelang/internal/token"
+
+type Node interface {
+	Pos() token.Position
+	End() token.Position
+}
+
+type ProgramItem interface {
+	Node
+	programItemNode()
+}
+
+type Program struct {
+	Items  []ProgramItem
+	Start  token.Position
+	Finish token.Position
+}
+
+func (p *Program) Pos() token.Position { return p.Start }
+func (p *Program) End() token.Position { return p.Finish }
+
+type Statement interface {
+	ProgramItem
+	statementNode()
+}
+
+type Expression interface {
+	Node
+	expressionNode()
+}
+
+type Pattern interface {
+	Node
+	patternNode()
+}
+
+type Identifier struct {
+	Name   string
+	Start  token.Position
+	Finish token.Position
+}
+
+func (i *Identifier) Pos() token.Position { return i.Start }
+func (i *Identifier) End() token.Position { return i.Finish }
+func (i *Identifier) expressionNode()     {}
+func (i *Identifier) patternNode()        {}
+
+// Literals
+
+type NumberLiteral struct {
+	Value  string
+	Start  token.Position
+	Finish token.Position
+}
+
+func (n *NumberLiteral) Pos() token.Position { return n.Start }
+func (n *NumberLiteral) End() token.Position { return n.Finish }
+func (n *NumberLiteral) expressionNode()     {}
+func (n *NumberLiteral) patternNode()        {}
+
+type StringLiteral struct {
+	Value  string
+	Start  token.Position
+	Finish token.Position
+}
+
+func (s *StringLiteral) Pos() token.Position { return s.Start }
+func (s *StringLiteral) End() token.Position { return s.Finish }
+func (s *StringLiteral) expressionNode()     {}
+func (s *StringLiteral) patternNode()        {}
+
+type BooleanLiteral struct {
+	Value  bool
+	Start  token.Position
+	Finish token.Position
+}
+
+func (b *BooleanLiteral) Pos() token.Position { return b.Start }
+func (b *BooleanLiteral) End() token.Position { return b.Finish }
+func (b *BooleanLiteral) expressionNode()     {}
+func (b *BooleanLiteral) patternNode()        {}
+
+type NullLiteral struct {
+	Start  token.Position
+	Finish token.Position
+}
+
+func (n *NullLiteral) Pos() token.Position { return n.Start }
+func (n *NullLiteral) End() token.Position { return n.Finish }
+func (n *NullLiteral) expressionNode()     {}
+func (n *NullLiteral) patternNode()        {}
+
+// Composite literals
+
+type ArrayLiteral struct {
+	Elements []Expression
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (a *ArrayLiteral) Pos() token.Position { return a.Start }
+func (a *ArrayLiteral) End() token.Position { return a.Finish }
+func (a *ArrayLiteral) expressionNode()     {}
+
+type ObjectPair struct {
+	Key             string
+	KeyIsIdentifier bool
+	Value           Expression
+}
+
+type ObjectLiteral struct {
+	Pairs  []ObjectPair
+	Start  token.Position
+	Finish token.Position
+}
+
+func (o *ObjectLiteral) Pos() token.Position { return o.Start }
+func (o *ObjectLiteral) End() token.Position { return o.Finish }
+func (o *ObjectLiteral) expressionNode()     {}
+
+// Expressions
+
+type AwaitExpression struct {
+	Expression Expression
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (a *AwaitExpression) Pos() token.Position { return a.Start }
+func (a *AwaitExpression) End() token.Position { return a.Finish }
+func (a *AwaitExpression) expressionNode()     {}
+
+type PrefixExpression struct {
+	Operator string
+	Right    Expression
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (p *PrefixExpression) Pos() token.Position { return p.Start }
+func (p *PrefixExpression) End() token.Position { return p.Finish }
+func (p *PrefixExpression) expressionNode()     {}
+
+type InfixExpression struct {
+	Left     Expression
+	Operator string
+	Right    Expression
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (i *InfixExpression) Pos() token.Position { return i.Start }
+func (i *InfixExpression) End() token.Position { return i.Finish }
+func (i *InfixExpression) expressionNode()     {}
+
+type AssignmentExpression struct {
+	Target Expression
+	Value  Expression
+	Start  token.Position
+	Finish token.Position
+}
+
+func (a *AssignmentExpression) Pos() token.Position { return a.Start }
+func (a *AssignmentExpression) End() token.Position { return a.Finish }
+func (a *AssignmentExpression) expressionNode()     {}
+
+type ElvisExpression struct {
+	Left   Expression
+	Right  Expression
+	Start  token.Position
+	Finish token.Position
+}
+
+func (e *ElvisExpression) Pos() token.Position { return e.Start }
+func (e *ElvisExpression) End() token.Position { return e.Finish }
+func (e *ElvisExpression) expressionNode()     {}
+
+type CallExpression struct {
+	Callee    Expression
+	Arguments []Expression
+	Start     token.Position
+	Finish    token.Position
+}
+
+func (c *CallExpression) Pos() token.Position { return c.Start }
+func (c *CallExpression) End() token.Position { return c.Finish }
+func (c *CallExpression) expressionNode()     {}
+
+type IndexExpression struct {
+	Collection Expression
+	Index      Expression
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (i *IndexExpression) Pos() token.Position { return i.Start }
+func (i *IndexExpression) End() token.Position { return i.Finish }
+func (i *IndexExpression) expressionNode()     {}
+
+type MemberExpression struct {
+	Object   Expression
+	Property string
+	Optional bool
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (m *MemberExpression) Pos() token.Position { return m.Start }
+func (m *MemberExpression) End() token.Position { return m.Finish }
+func (m *MemberExpression) expressionNode()     {}
+
+type NonNullAssertion struct {
+	Expression Expression
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (n *NonNullAssertion) Pos() token.Position { return n.Start }
+func (n *NonNullAssertion) End() token.Position { return n.Finish }
+func (n *NonNullAssertion) expressionNode()     {}
+
+// Statements
+
+type BlockStatement struct {
+	Statements []Statement
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (b *BlockStatement) Pos() token.Position { return b.Start }
+func (b *BlockStatement) End() token.Position { return b.Finish }
+func (b *BlockStatement) statementNode()      {}
+func (b *BlockStatement) programItemNode()    {}
+
+type ExpressionStatement struct {
+	Expression Expression
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (e *ExpressionStatement) Pos() token.Position { return e.Start }
+func (e *ExpressionStatement) End() token.Position { return e.Finish }
+func (e *ExpressionStatement) statementNode()      {}
+func (e *ExpressionStatement) programItemNode()    {}
+
+type VariableDeclaration struct {
+	Mutable bool
+	Name    *Identifier
+	Type    *TypeAnnotation
+	Value   Expression
+	Start   token.Position
+	Finish  token.Position
+}
+
+func (v *VariableDeclaration) Pos() token.Position { return v.Start }
+func (v *VariableDeclaration) End() token.Position { return v.Finish }
+func (v *VariableDeclaration) statementNode()      {}
+func (v *VariableDeclaration) programItemNode()    {}
+
+type Parameter struct {
+	Name *Identifier
+	Type *TypeAnnotation
+}
+
+type TypeAnnotation struct {
+	Name     *Identifier
+	TypeArgs []*TypeAnnotation
+	Nullable bool
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (t *TypeAnnotation) Pos() token.Position { return t.Start }
+func (t *TypeAnnotation) End() token.Position { return t.Finish }
+
+// Functions and contracts
+
+type FunctionDeclaration struct {
+	Name       *Identifier
+	TypeParams []*Identifier
+	Params     []Parameter
+	ReturnType *TypeAnnotation
+	Async      bool
+	Contract   *ContractBlock
+	Body       *BlockStatement
+	BodyExpr   Expression
+	IsExprBody bool
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (f *FunctionDeclaration) Pos() token.Position { return f.Start }
+func (f *FunctionDeclaration) End() token.Position { return f.Finish }
+func (f *FunctionDeclaration) statementNode()      {}
+func (f *FunctionDeclaration) programItemNode()    {}
+
+type ContractBlock struct {
+	Clauses []ContractClause
+	Start   token.Position
+	Finish  token.Position
+}
+
+func (c *ContractBlock) Pos() token.Position { return c.Start }
+func (c *ContractBlock) End() token.Position { return c.Finish }
+
+type ContractClause struct {
+	Guard     Expression
+	Condition Expression
+	Start     token.Position
+	Finish    token.Position
+}
+
+func (c *ContractClause) Pos() token.Position { return c.Start }
+func (c *ContractClause) End() token.Position { return c.Finish }
+
+type ClassDeclaration struct {
+	Name       *Identifier
+	Params     []Parameter
+	SuperClass *Identifier
+	Body       *BlockStatement
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (c *ClassDeclaration) Pos() token.Position { return c.Start }
+func (c *ClassDeclaration) End() token.Position { return c.Finish }
+func (c *ClassDeclaration) statementNode()      {}
+func (c *ClassDeclaration) programItemNode()    {}
+
+type StructDeclaration struct {
+	Name   *Identifier
+	Params []Parameter
+	Body   *BlockStatement
+	Start  token.Position
+	Finish token.Position
+}
+
+func (s *StructDeclaration) Pos() token.Position { return s.Start }
+func (s *StructDeclaration) End() token.Position { return s.Finish }
+func (s *StructDeclaration) statementNode()      {}
+func (s *StructDeclaration) programItemNode()    {}
+
+type EnumDeclaration struct {
+	Name       *Identifier
+	TypeParams []*Identifier
+	Cases      []EnumCase
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (e *EnumDeclaration) Pos() token.Position { return e.Start }
+func (e *EnumDeclaration) End() token.Position { return e.Finish }
+func (e *EnumDeclaration) statementNode()      {}
+func (e *EnumDeclaration) programItemNode()    {}
+
+type EnumCase struct {
+	Name   *Identifier
+	Params []Parameter
+	Start  token.Position
+	Finish token.Position
+}
+
+func (e *EnumCase) Pos() token.Position { return e.Start }
+func (e *EnumCase) End() token.Position { return e.Finish }
+
+type ContractDeclaration struct {
+	Name   *Identifier
+	Body   *BlockStatement
+	Start  token.Position
+	Finish token.Position
+}
+
+func (c *ContractDeclaration) Pos() token.Position { return c.Start }
+func (c *ContractDeclaration) End() token.Position { return c.Finish }
+func (c *ContractDeclaration) statementNode()      {}
+func (c *ContractDeclaration) programItemNode()    {}
+
+type ImportDeclaration struct {
+	Path   []*Identifier
+	Alias  *Identifier
+	Start  token.Position
+	Finish token.Position
+}
+
+func (i *ImportDeclaration) Pos() token.Position { return i.Start }
+func (i *ImportDeclaration) End() token.Position { return i.Finish }
+func (i *ImportDeclaration) statementNode()      {}
+func (i *ImportDeclaration) programItemNode()    {}
+
+type ModuleDeclaration struct {
+	Name   *Identifier
+	Body   *BlockStatement
+	Start  token.Position
+	Finish token.Position
+}
+
+func (m *ModuleDeclaration) Pos() token.Position { return m.Start }
+func (m *ModuleDeclaration) End() token.Position { return m.Finish }
+func (m *ModuleDeclaration) programItemNode()    {}
+
+type MatchStatement struct {
+	Value  Expression
+	Cases  []MatchCase
+	Start  token.Position
+	Finish token.Position
+}
+
+func (m *MatchStatement) Pos() token.Position { return m.Start }
+func (m *MatchStatement) End() token.Position { return m.Finish }
+func (m *MatchStatement) statementNode()      {}
+func (m *MatchStatement) programItemNode()    {}
+
+type MatchCase struct {
+	Pattern Pattern
+	Body    Statement
+	Start   token.Position
+	Finish  token.Position
+}
+
+func (m *MatchCase) Pos() token.Position { return m.Start }
+func (m *MatchCase) End() token.Position { return m.Finish }
+
+type PatternPair struct {
+	Key             string
+	KeyIsIdentifier bool
+	Value           Pattern
+}
+
+type ObjectPattern struct {
+	Pairs  []PatternPair
+	Start  token.Position
+	Finish token.Position
+}
+
+func (o *ObjectPattern) Pos() token.Position { return o.Start }
+func (o *ObjectPattern) End() token.Position { return o.Finish }
+func (o *ObjectPattern) patternNode()        {}
+
+type StructPattern struct {
+	Name   *Identifier
+	Fields []Pattern
+	Start  token.Position
+	Finish token.Position
+}
+
+func (s *StructPattern) Pos() token.Position { return s.Start }
+func (s *StructPattern) End() token.Position { return s.Finish }
+func (s *StructPattern) patternNode()        {}
+
+type IdentifierPattern struct {
+	Identifier *Identifier
+}
+
+func (i *IdentifierPattern) Pos() token.Position { return i.Identifier.Pos() }
+func (i *IdentifierPattern) End() token.Position { return i.Identifier.End() }
+func (i *IdentifierPattern) patternNode()        {}
+
+type LiteralPattern struct {
+	Value Expression
+}
+
+func (l *LiteralPattern) Pos() token.Position { return l.Value.Pos() }
+func (l *LiteralPattern) End() token.Position { return l.Value.End() }
+func (l *LiteralPattern) patternNode()        {}

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -1,0 +1,364 @@
+package lexer
+
+import (
+	"strings"
+
+	"selenelang/internal/token"
+)
+
+type Lexer struct {
+	input        []rune
+	position     int
+	readPosition int
+	ch           rune
+	line         int
+	column       int
+}
+
+func New(input string) *Lexer {
+	l := &Lexer{
+		input: []rune(input),
+		line:  1,
+	}
+	l.readRune()
+	return l
+}
+
+func (l *Lexer) NextToken() token.Token {
+	l.skipWhitespaceAndComments()
+
+	startOffset := l.position
+	startLine := l.line
+	startColumn := l.column
+
+	tok := token.Token{
+		Pos: token.Position{Offset: startOffset, Line: startLine, Column: startColumn},
+	}
+
+	switch l.ch {
+	case 0:
+		tok.Type = token.EOF
+		tok.Literal = ""
+		tok.End = tok.Pos
+		return tok
+	case '+':
+		tok.Type = token.PLUS
+		tok.Literal = "+"
+		l.readRune()
+	case '-':
+		tok.Type = token.MINUS
+		tok.Literal = "-"
+		l.readRune()
+	case '*':
+		tok.Type = token.ASTERISK
+		tok.Literal = "*"
+		l.readRune()
+	case '%':
+		tok.Type = token.PERCENT
+		tok.Literal = "%"
+		l.readRune()
+	case ',':
+		tok.Type = token.COMMA
+		tok.Literal = ","
+		l.readRune()
+	case ';':
+		tok.Type = token.SEMICOLON
+		tok.Literal = ";"
+		l.readRune()
+	case '(':
+		tok.Type = token.LPAREN
+		tok.Literal = "("
+		l.readRune()
+	case ')':
+		tok.Type = token.RPAREN
+		tok.Literal = ")"
+		l.readRune()
+	case '{':
+		tok.Type = token.LBRACE
+		tok.Literal = "{"
+		l.readRune()
+	case '}':
+		tok.Type = token.RBRACE
+		tok.Literal = "}"
+		l.readRune()
+	case '[':
+		tok.Type = token.LBRACKET
+		tok.Literal = "["
+		l.readRune()
+	case ']':
+		tok.Type = token.RBRACKET
+		tok.Literal = "]"
+		l.readRune()
+	case '.':
+		tok.Type = token.DOT
+		tok.Literal = "."
+		l.readRune()
+	case ':':
+		tok.Type = token.COLON
+		tok.Literal = ":"
+		l.readRune()
+	case '?':
+		switch l.peekRune() {
+		case ':':
+			tok.Type = token.ELVIS
+			tok.Literal = "?:"
+			l.readRune()
+			l.readRune()
+		case '.':
+			tok.Type = token.SAFE_DOT
+			tok.Literal = "?."
+			l.readRune()
+			l.readRune()
+		default:
+			tok.Type = token.QUESTION
+			tok.Literal = "?"
+			l.readRune()
+		}
+	case '!':
+		switch l.peekRune() {
+		case '=':
+			tok.Type = token.NOT_EQ
+			tok.Literal = "!="
+			l.readRune()
+			l.readRune()
+		case '!':
+			tok.Type = token.NON_NULL
+			tok.Literal = "!!"
+			l.readRune()
+			l.readRune()
+		default:
+			if l.peekWord("is") {
+				tok.Type = token.NOT_IS
+				tok.Literal = "!is"
+				l.readRune()
+				l.readRune() // consume 'i'
+				l.readRune() // consume 's'
+			} else {
+				tok.Type = token.BANG
+				tok.Literal = "!"
+				l.readRune()
+			}
+		}
+	case '=':
+		switch l.peekRune() {
+		case '=':
+			tok.Type = token.EQ
+			tok.Literal = "=="
+			l.readRune()
+			l.readRune()
+		case '>':
+			tok.Type = token.ARROW
+			tok.Literal = "=>"
+			l.readRune()
+			l.readRune()
+		default:
+			tok.Type = token.ASSIGN
+			tok.Literal = "="
+			l.readRune()
+		}
+	case '<':
+		if l.peekRune() == '=' {
+			tok.Type = token.LTE
+			tok.Literal = "<="
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.LT
+			tok.Literal = "<"
+			l.readRune()
+		}
+	case '>':
+		if l.peekRune() == '=' {
+			tok.Type = token.GTE
+			tok.Literal = ">="
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.GT
+			tok.Literal = ">"
+			l.readRune()
+		}
+	case '&':
+		if l.peekRune() == '&' {
+			tok.Type = token.AND
+			tok.Literal = "&&"
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.ILLEGAL
+			tok.Literal = string(l.ch)
+			l.readRune()
+		}
+	case '|':
+		if l.peekRune() == '|' {
+			tok.Type = token.OR
+			tok.Literal = "||"
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.ILLEGAL
+			tok.Literal = string(l.ch)
+			l.readRune()
+		}
+	case '/':
+		tok.Type = token.SLASH
+		tok.Literal = "/"
+		l.readRune()
+	case '"':
+		lit := l.readString()
+		tok.Type = token.STRING
+		tok.Literal = lit
+	default:
+		if isLetter(l.ch) {
+			literal := l.readIdentifier()
+			tok.Type = token.LookupIdent(literal)
+			tok.Literal = literal
+		} else if isDigit(l.ch) {
+			literal := l.readNumber()
+			tok.Type = token.NUMBER
+			tok.Literal = literal
+		} else {
+			tok.Type = token.ILLEGAL
+			tok.Literal = string(l.ch)
+			l.readRune()
+		}
+	}
+
+	tok.End = token.Position{Offset: l.position, Line: l.line, Column: l.column}
+	return tok
+}
+
+func (l *Lexer) readRune() {
+	if l.readPosition >= len(l.input) {
+		l.position = len(l.input)
+		l.ch = 0
+		return
+	}
+	l.position = l.readPosition
+	l.ch = l.input[l.readPosition]
+	l.readPosition++
+	if l.ch == '\n' {
+		l.line++
+		l.column = 0
+	} else {
+		l.column++
+	}
+}
+
+func (l *Lexer) peekRune() rune {
+	if l.readPosition >= len(l.input) {
+		return 0
+	}
+	return l.input[l.readPosition]
+}
+
+func (l *Lexer) peekWord(word string) bool {
+	if len(word) == 0 {
+		return false
+	}
+	if l.peekRune() != rune(word[0]) {
+		return false
+	}
+	if l.readPosition+len(word) > len(l.input) {
+		return false
+	}
+	for i, r := range word {
+		if l.readPosition+i >= len(l.input) {
+			return false
+		}
+		if l.input[l.readPosition+i] != r {
+			return false
+		}
+	}
+	nextIndex := l.readPosition + len(word)
+	if nextIndex < len(l.input) {
+		next := l.input[nextIndex]
+		if isLetter(next) || isDigit(next) || next == '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func (l *Lexer) readIdentifier() string {
+	start := l.position
+	for isLetter(l.ch) || isDigit(l.ch) || l.ch == '_' {
+		l.readRune()
+	}
+	return string(l.input[start:l.position])
+}
+
+func (l *Lexer) readNumber() string {
+	start := l.position
+	for isDigit(l.ch) {
+		l.readRune()
+	}
+	return string(l.input[start:l.position])
+}
+
+func (l *Lexer) readString() string {
+	l.readRune() // consume opening quote
+	start := l.position
+	for l.ch != '"' && l.ch != 0 {
+		if l.ch == '\\' {
+			l.readRune()
+		}
+		l.readRune()
+	}
+	literal := string(l.input[start:l.position])
+	if l.ch == '"' {
+		l.readRune() // consume closing quote
+	}
+	return literal
+}
+
+func (l *Lexer) skipWhitespaceAndComments() {
+	for {
+		for l.ch == ' ' || l.ch == '\t' || l.ch == '\n' || l.ch == '\r' {
+			l.readRune()
+		}
+		if l.ch == '/' {
+			switch l.peekRune() {
+			case '/':
+				l.consumeLineComment()
+				continue
+			case '*':
+				l.consumeBlockComment()
+				continue
+			}
+		}
+		break
+	}
+}
+
+func (l *Lexer) consumeLineComment() {
+	l.readRune() // consume first '/'
+	l.readRune() // consume second '/'
+	for l.ch != '\n' && l.ch != 0 {
+		l.readRune()
+	}
+}
+
+func (l *Lexer) consumeBlockComment() {
+	l.readRune() // consume first '/'
+	l.readRune() // consume '*'
+	for {
+		if l.ch == 0 {
+			return
+		}
+		if l.ch == '*' && l.peekRune() == '/' {
+			l.readRune()
+			l.readRune()
+			return
+		}
+		l.readRune()
+	}
+}
+
+func isLetter(ch rune) bool {
+	return ch == '_' || strings.ContainsRune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", ch)
+}
+
+func isDigit(ch rune) bool {
+	return ch >= '0' && ch <= '9'
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,0 +1,997 @@
+package parser
+
+import (
+	"fmt"
+
+	"selenelang/internal/ast"
+	"selenelang/internal/lexer"
+	"selenelang/internal/token"
+)
+
+type (
+	prefixParseFn func() ast.Expression
+	infixParseFn  func(ast.Expression) ast.Expression
+)
+
+type Parser struct {
+	l *lexer.Lexer
+
+	curToken  token.Token
+	peekToken token.Token
+
+	errors []string
+
+	prefixParseFns map[token.Type]prefixParseFn
+	infixParseFns  map[token.Type]infixParseFn
+}
+
+const (
+	_ int = iota
+	LOWEST
+	ASSIGNMENT
+	ELVIS
+	OR
+	AND
+	EQUALITY
+	COMPARISON
+	SUM
+	PRODUCT
+	PREFIX
+	CALL
+)
+
+var precedences = map[token.Type]int{
+	token.ASSIGN:   ASSIGNMENT,
+	token.ELVIS:    ELVIS,
+	token.OR:       OR,
+	token.AND:      AND,
+	token.EQ:       EQUALITY,
+	token.NOT_EQ:   EQUALITY,
+	token.LT:       COMPARISON,
+	token.LTE:      COMPARISON,
+	token.GT:       COMPARISON,
+	token.GTE:      COMPARISON,
+	token.IS:       COMPARISON,
+	token.NOT_IS:   COMPARISON,
+	token.PLUS:     SUM,
+	token.MINUS:    SUM,
+	token.ASTERISK: PRODUCT,
+	token.SLASH:    PRODUCT,
+	token.PERCENT:  PRODUCT,
+	token.LPAREN:   CALL,
+	token.LBRACKET: CALL,
+	token.DOT:      CALL,
+	token.SAFE_DOT: CALL,
+	token.NON_NULL: CALL,
+}
+
+func New(l *lexer.Lexer) *Parser {
+	p := &Parser{
+		l:              l,
+		prefixParseFns: make(map[token.Type]prefixParseFn),
+		infixParseFns:  make(map[token.Type]infixParseFn),
+	}
+
+	// Read two tokens so cur and peek are set
+	p.nextToken()
+	p.nextToken()
+
+	p.registerPrefix(token.IDENT, p.parseIdentifier)
+	p.registerPrefix(token.NUMBER, p.parseNumberLiteral)
+	p.registerPrefix(token.STRING, p.parseStringLiteral)
+	p.registerPrefix(token.TRUE, p.parseBooleanLiteral)
+	p.registerPrefix(token.FALSE, p.parseBooleanLiteral)
+	p.registerPrefix(token.NULL, p.parseNullLiteral)
+	p.registerPrefix(token.MINUS, p.parsePrefixExpression)
+	p.registerPrefix(token.BANG, p.parsePrefixExpression)
+	p.registerPrefix(token.LPAREN, p.parseGroupedExpression)
+	p.registerPrefix(token.LBRACKET, p.parseArrayLiteral)
+	p.registerPrefix(token.LBRACE, p.parseObjectLiteral)
+	p.registerPrefix(token.AWAIT, p.parseAwaitExpression)
+
+	p.registerInfix(token.PLUS, p.parseInfixExpression)
+	p.registerInfix(token.MINUS, p.parseInfixExpression)
+	p.registerInfix(token.ASTERISK, p.parseInfixExpression)
+	p.registerInfix(token.SLASH, p.parseInfixExpression)
+	p.registerInfix(token.PERCENT, p.parseInfixExpression)
+	p.registerInfix(token.EQ, p.parseInfixExpression)
+	p.registerInfix(token.NOT_EQ, p.parseInfixExpression)
+	p.registerInfix(token.LT, p.parseInfixExpression)
+	p.registerInfix(token.LTE, p.parseInfixExpression)
+	p.registerInfix(token.GT, p.parseInfixExpression)
+	p.registerInfix(token.GTE, p.parseInfixExpression)
+	p.registerInfix(token.OR, p.parseInfixExpression)
+	p.registerInfix(token.AND, p.parseInfixExpression)
+	p.registerInfix(token.IS, p.parseInfixExpression)
+	p.registerInfix(token.NOT_IS, p.parseInfixExpression)
+	p.registerInfix(token.ELVIS, p.parseElvisExpression)
+	p.registerInfix(token.ASSIGN, p.parseAssignmentExpression)
+	p.registerInfix(token.LPAREN, p.parseCallExpression)
+	p.registerInfix(token.LBRACKET, p.parseIndexExpression)
+	p.registerInfix(token.DOT, p.parseMemberExpression)
+	p.registerInfix(token.SAFE_DOT, p.parseMemberExpression)
+	p.registerInfix(token.NON_NULL, p.parseNonNullAssertion)
+
+	return p
+}
+
+func (p *Parser) Errors() []string {
+	return p.errors
+}
+
+func (p *Parser) nextToken() {
+	p.curToken = p.peekToken
+	p.peekToken = p.l.NextToken()
+}
+
+func (p *Parser) registerPrefix(t token.Type, fn prefixParseFn) {
+	p.prefixParseFns[t] = fn
+}
+
+func (p *Parser) registerInfix(t token.Type, fn infixParseFn) {
+	p.infixParseFns[t] = fn
+}
+
+func (p *Parser) ParseProgram() *ast.Program {
+	program := &ast.Program{}
+	if p.curToken.Type != token.EOF {
+		program.Start = p.curToken.Pos
+	}
+
+	for p.curToken.Type != token.EOF {
+		var item ast.ProgramItem
+		if p.curToken.Type == token.MODULE {
+			item = p.parseModuleDeclaration()
+		} else {
+			stmt := p.parseStatement()
+			if stmt != nil {
+				item = stmt
+			}
+		}
+		if item != nil {
+			program.Items = append(program.Items, item)
+		}
+		p.nextToken()
+	}
+
+	program.Finish = p.curToken.Pos
+	return program
+}
+
+func (p *Parser) parseStatement() ast.Statement {
+	switch p.curToken.Type {
+	case token.LET, token.VAR:
+		return p.parseVariableDeclaration()
+	case token.FN:
+		return p.parseFunctionDeclaration()
+	case token.CLASS:
+		return p.parseClassDeclaration()
+	case token.STRUCT:
+		return p.parseStructDeclaration()
+	case token.ENUM:
+		return p.parseEnumDeclaration()
+	case token.CONTRACT:
+		return p.parseContractDeclaration()
+	case token.IMPORT:
+		return p.parseImportDeclaration()
+	case token.MATCH:
+		return p.parseMatchStatement()
+	case token.LBRACE:
+		return p.parseBlockStatement()
+	default:
+		return p.parseExpressionStatement()
+	}
+}
+
+func (p *Parser) parseModuleDeclaration() ast.ProgramItem {
+	module := &ast.ModuleDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	module.Name = p.currentIdentifier()
+
+	if !p.expectPeek(token.LBRACE) {
+		return nil
+	}
+	block := p.parseBlockStatement()
+	module.Body = block
+	if block != nil {
+		module.Finish = block.End()
+	} else {
+		module.Finish = p.curToken.End
+	}
+	return module
+}
+
+func (p *Parser) parseVariableDeclaration() ast.Statement {
+	stmt := &ast.VariableDeclaration{Start: p.curToken.Pos, Mutable: p.curToken.Type == token.VAR}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	stmt.Name = p.currentIdentifier()
+
+	if p.peekTokenIs(token.COLON) {
+		p.nextToken()
+		p.nextToken()
+		stmt.Type = p.parseTypeAnnotation()
+	}
+
+	if !p.expectPeek(token.ASSIGN) {
+		return nil
+	}
+
+	p.nextToken()
+	stmt.Value = p.parseExpression(LOWEST)
+	if stmt.Value != nil {
+		stmt.Finish = stmt.Value.End()
+	}
+
+	if !p.expectPeek(token.SEMICOLON) {
+		return stmt
+	}
+	stmt.Finish = p.curToken.End
+	return stmt
+}
+
+func (p *Parser) parseFunctionDeclaration() ast.Statement {
+	fn := &ast.FunctionDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	fn.Name = p.currentIdentifier()
+
+	if p.peekTokenIs(token.LT) {
+		fn.TypeParams = p.parseTypeParameters()
+	}
+
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+	p.nextToken()
+	fn.Params = p.parseParameterList(token.RPAREN)
+
+	if p.peekTokenIs(token.COLON) {
+		p.nextToken()
+		p.nextToken()
+		fn.ReturnType = p.parseTypeAnnotation()
+	}
+
+	if p.peekTokenIs(token.ASYNC) {
+		p.nextToken()
+		fn.Async = true
+	}
+
+	if p.peekTokenIs(token.CONTRACT) {
+		p.nextToken()
+		fn.Contract = p.parseContractBlock()
+	}
+
+	if p.peekTokenIs(token.LBRACE) {
+		p.nextToken()
+		fn.Body = p.parseBlockStatement()
+		if fn.Body != nil {
+			fn.Finish = fn.Body.End()
+		}
+	} else if p.peekTokenIs(token.ASSIGN) {
+		p.nextToken()
+		p.nextToken()
+		fn.IsExprBody = true
+		fn.BodyExpr = p.parseExpression(LOWEST)
+		if fn.BodyExpr != nil {
+			fn.Finish = fn.BodyExpr.End()
+		}
+		if p.peekTokenIs(token.SEMICOLON) {
+			p.nextToken()
+			fn.Finish = p.curToken.End
+		}
+	} else {
+		fn.Finish = p.curToken.End
+	}
+
+	return fn
+}
+
+func (p *Parser) parseClassDeclaration() ast.Statement {
+	class := &ast.ClassDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	class.Name = p.currentIdentifier()
+
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+	p.nextToken()
+	class.Params = p.parseParameterList(token.RPAREN)
+
+	if p.peekTokenIs(token.COLON) {
+		p.nextToken()
+		if !p.expectPeek(token.IDENT) {
+			return class
+		}
+		class.SuperClass = p.currentIdentifier()
+	}
+
+	if p.peekTokenIs(token.LBRACE) {
+		p.nextToken()
+		class.Body = p.parseBlockStatement()
+		if class.Body != nil {
+			class.Finish = class.Body.End()
+		}
+	} else {
+		class.Finish = p.curToken.End
+	}
+	return class
+}
+
+func (p *Parser) parseStructDeclaration() ast.Statement {
+	st := &ast.StructDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	st.Name = p.currentIdentifier()
+
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+	p.nextToken()
+	st.Params = p.parseParameterList(token.RPAREN)
+
+	if p.peekTokenIs(token.LBRACE) {
+		p.nextToken()
+		st.Body = p.parseBlockStatement()
+		if st.Body != nil {
+			st.Finish = st.Body.End()
+		}
+	} else {
+		st.Finish = p.curToken.End
+	}
+	return st
+}
+
+func (p *Parser) parseEnumDeclaration() ast.Statement {
+	enumNode := &ast.EnumDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	enumNode.Name = p.currentIdentifier()
+
+	if p.peekTokenIs(token.LT) {
+		enumNode.TypeParams = p.parseTypeParameters()
+	}
+
+	if !p.expectPeek(token.LBRACE) {
+		return nil
+	}
+	p.nextToken()
+	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
+		caseNode := p.parseEnumCase()
+		if caseNode != nil {
+			enumNode.Cases = append(enumNode.Cases, *caseNode)
+			enumNode.Finish = caseNode.End()
+		}
+		p.nextToken()
+	}
+	if p.curTokenIs(token.RBRACE) {
+		enumNode.Finish = p.curToken.End
+	}
+	return enumNode
+}
+
+func (p *Parser) parseEnumCase() *ast.EnumCase {
+	caseNode := &ast.EnumCase{Start: p.curToken.Pos}
+	if p.curToken.Type != token.IDENT {
+		p.errors = append(p.errors, fmt.Sprintf("expected enum case identifier, got %s", p.curToken.Type))
+		return nil
+	}
+	caseNode.Name = p.currentIdentifier()
+
+	if p.peekTokenIs(token.LPAREN) {
+		p.nextToken()
+		p.nextToken()
+		caseNode.Params = p.parseParameterList(token.RPAREN)
+	}
+
+	if !p.expectPeek(token.SEMICOLON) {
+		return caseNode
+	}
+	caseNode.Finish = p.curToken.End
+	return caseNode
+}
+
+func (p *Parser) parseContractDeclaration() ast.Statement {
+	contract := &ast.ContractDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	contract.Name = p.currentIdentifier()
+
+	if !p.expectPeek(token.LBRACE) {
+		return contract
+	}
+	contract.Body = p.parseBlockStatement()
+	if contract.Body != nil {
+		contract.Finish = contract.Body.End()
+	}
+	return contract
+}
+
+func (p *Parser) parseImportDeclaration() ast.Statement {
+	imp := &ast.ImportDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	imp.Path = append(imp.Path, p.currentIdentifier())
+	for p.peekTokenIs(token.DOT) {
+		p.nextToken()
+		if !p.expectPeek(token.IDENT) {
+			return imp
+		}
+		imp.Path = append(imp.Path, p.currentIdentifier())
+	}
+
+	if p.peekTokenIs(token.AS) {
+		p.nextToken()
+		if !p.expectPeek(token.IDENT) {
+			return imp
+		}
+		imp.Alias = p.currentIdentifier()
+	}
+
+	if !p.expectPeek(token.SEMICOLON) {
+		return imp
+	}
+	imp.Finish = p.curToken.End
+	return imp
+}
+
+func (p *Parser) parseMatchStatement() ast.Statement {
+	match := &ast.MatchStatement{Start: p.curToken.Pos}
+	p.nextToken()
+	match.Value = p.parseExpression(LOWEST)
+	if !p.expectPeek(token.LBRACE) {
+		return match
+	}
+	p.nextToken()
+	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
+		caseNode := p.parseMatchCase()
+		if caseNode != nil {
+			match.Cases = append(match.Cases, *caseNode)
+			match.Finish = caseNode.End()
+		}
+		p.nextToken()
+	}
+	if p.curTokenIs(token.RBRACE) {
+		match.Finish = p.curToken.End
+	}
+	return match
+}
+
+func (p *Parser) parseMatchCase() *ast.MatchCase {
+	caseNode := &ast.MatchCase{Start: p.curToken.Pos}
+	pattern := p.parsePattern()
+	caseNode.Pattern = pattern
+
+	if !p.expectPeek(token.ARROW) {
+		return caseNode
+	}
+	p.nextToken()
+	body := p.parseStatement()
+	caseNode.Body = body
+	if body != nil {
+		caseNode.Finish = body.End()
+	}
+	return caseNode
+}
+
+func (p *Parser) parseBlockStatement() *ast.BlockStatement {
+	block := &ast.BlockStatement{Start: p.curToken.Pos}
+	p.nextToken()
+	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
+		stmt := p.parseStatement()
+		if stmt != nil {
+			block.Statements = append(block.Statements, stmt)
+		}
+		p.nextToken()
+	}
+	block.Finish = p.curToken.End
+	return block
+}
+
+func (p *Parser) parseExpressionStatement() ast.Statement {
+	stmt := &ast.ExpressionStatement{Start: p.curToken.Pos}
+	stmt.Expression = p.parseExpression(LOWEST)
+	if stmt.Expression != nil {
+		stmt.Finish = stmt.Expression.End()
+	}
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		stmt.Finish = p.curToken.End
+	}
+	return stmt
+}
+
+func (p *Parser) parseTypeParameters() []*ast.Identifier {
+	params := []*ast.Identifier{}
+	if !p.expectPeek(token.LT) {
+		return params
+	}
+	if !p.expectPeek(token.IDENT) {
+		return params
+	}
+	params = append(params, p.currentIdentifier())
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		if !p.expectPeek(token.IDENT) {
+			return params
+		}
+		params = append(params, p.currentIdentifier())
+	}
+	if !p.expectPeek(token.GT) {
+		return params
+	}
+	return params
+}
+
+func (p *Parser) parseParameterList(end token.Type) []ast.Parameter {
+	params := []ast.Parameter{}
+	if p.curTokenIs(end) {
+		return params
+	}
+	param := p.parseParameter()
+	params = append(params, param)
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		params = append(params, p.parseParameter())
+	}
+	if !p.expectPeek(end) {
+		return params
+	}
+	return params
+}
+
+func (p *Parser) parseParameter() ast.Parameter {
+	param := ast.Parameter{}
+	if p.curToken.Type != token.IDENT {
+		p.errors = append(p.errors, fmt.Sprintf("expected parameter name, got %s", p.curToken.Type))
+		return param
+	}
+	param.Name = p.currentIdentifier()
+	if !p.expectPeek(token.COLON) {
+		return param
+	}
+	p.nextToken()
+	param.Type = p.parseTypeAnnotation()
+	return param
+}
+
+func (p *Parser) parseTypeAnnotation() *ast.TypeAnnotation {
+	if p.curToken.Type != token.IDENT {
+		p.errors = append(p.errors, fmt.Sprintf("expected type identifier, got %s", p.curToken.Type))
+		return nil
+	}
+	typeNode := &ast.TypeAnnotation{Start: p.curToken.Pos}
+	typeNode.Name = p.currentIdentifier()
+
+	if p.peekTokenIs(token.LT) {
+		p.nextToken()
+		p.nextToken()
+		if arg := p.parseTypeAnnotation(); arg != nil {
+			typeNode.TypeArgs = append(typeNode.TypeArgs, arg)
+		}
+		for p.peekTokenIs(token.COMMA) {
+			p.nextToken()
+			p.nextToken()
+			if arg := p.parseTypeAnnotation(); arg != nil {
+				typeNode.TypeArgs = append(typeNode.TypeArgs, arg)
+			}
+		}
+		if !p.expectPeek(token.GT) {
+			return typeNode
+		}
+	}
+
+	if p.peekTokenIs(token.QUESTION) {
+		p.nextToken()
+		typeNode.Nullable = true
+	}
+
+	typeNode.Finish = p.curToken.End
+	return typeNode
+}
+
+func (p *Parser) parseContractBlock() *ast.ContractBlock {
+	block := &ast.ContractBlock{Start: p.curToken.Pos}
+	if !p.expectPeek(token.LBRACE) {
+		return block
+	}
+	p.nextToken()
+	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
+		clause := p.parseContractClause()
+		if clause != nil {
+			block.Clauses = append(block.Clauses, *clause)
+		}
+		p.nextToken()
+	}
+	block.Finish = p.curToken.End
+	return block
+}
+
+func (p *Parser) parseContractClause() *ast.ContractClause {
+	clause := &ast.ContractClause{Start: p.curToken.Pos}
+	if p.curToken.Type != token.RETURNS {
+		p.errors = append(p.errors, fmt.Sprintf("expected 'returns' in contract clause, got %s", p.curToken.Type))
+		return nil
+	}
+	if !p.expectPeek(token.LPAREN) {
+		return clause
+	}
+	if !p.peekTokenIs(token.RPAREN) {
+		p.nextToken()
+		clause.Guard = p.parseExpression(LOWEST)
+	}
+	if !p.expectPeek(token.RPAREN) {
+		return clause
+	}
+	if !p.expectPeek(token.ARROW) {
+		return clause
+	}
+	p.nextToken()
+	clause.Condition = p.parseExpression(LOWEST)
+	if !p.expectPeek(token.SEMICOLON) {
+		return clause
+	}
+	clause.Finish = p.curToken.End
+	return clause
+}
+
+func (p *Parser) parsePattern() ast.Pattern {
+	switch p.curToken.Type {
+	case token.NUMBER:
+		node := &ast.NumberLiteral{Value: p.curToken.Literal, Start: p.curToken.Pos, Finish: p.curToken.End}
+		return &ast.LiteralPattern{Value: node}
+	case token.STRING:
+		node := &ast.StringLiteral{Value: p.curToken.Literal, Start: p.curToken.Pos, Finish: p.curToken.End}
+		return &ast.LiteralPattern{Value: node}
+	case token.TRUE, token.FALSE:
+		node := &ast.BooleanLiteral{Value: p.curToken.Type == token.TRUE, Start: p.curToken.Pos, Finish: p.curToken.End}
+		return &ast.LiteralPattern{Value: node}
+	case token.NULL:
+		node := &ast.NullLiteral{Start: p.curToken.Pos, Finish: p.curToken.End}
+		return &ast.LiteralPattern{Value: node}
+	case token.IDENT:
+		ident := p.currentIdentifier()
+		if p.peekTokenIs(token.LPAREN) {
+			return p.parseStructPattern(ident)
+		}
+		return &ast.IdentifierPattern{Identifier: ident}
+	case token.LBRACE:
+		return p.parseObjectPattern()
+	default:
+		p.errors = append(p.errors, fmt.Sprintf("unexpected token in pattern: %s", p.curToken.Type))
+		return nil
+	}
+}
+
+func (p *Parser) parseStructPattern(name *ast.Identifier) ast.Pattern {
+	pattern := &ast.StructPattern{Name: name, Start: name.Pos()}
+	if !p.expectPeek(token.LPAREN) {
+		return pattern
+	}
+	p.nextToken()
+	if p.curTokenIs(token.RPAREN) {
+		pattern.Finish = p.curToken.End
+		return pattern
+	}
+	pattern.Fields = append(pattern.Fields, p.parsePattern())
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		pattern.Fields = append(pattern.Fields, p.parsePattern())
+	}
+	if !p.expectPeek(token.RPAREN) {
+		return pattern
+	}
+	pattern.Finish = p.curToken.End
+	return pattern
+}
+
+func (p *Parser) parseObjectPattern() ast.Pattern {
+	pattern := &ast.ObjectPattern{Start: p.curToken.Pos}
+	p.nextToken()
+	if p.curTokenIs(token.RBRACE) {
+		pattern.Finish = p.curToken.End
+		return pattern
+	}
+	pattern.Pairs = append(pattern.Pairs, p.parsePatternPair())
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		pattern.Pairs = append(pattern.Pairs, p.parsePatternPair())
+	}
+	if !p.expectPeek(token.RBRACE) {
+		return pattern
+	}
+	pattern.Finish = p.curToken.End
+	return pattern
+}
+
+func (p *Parser) parsePatternPair() ast.PatternPair {
+	pair := ast.PatternPair{}
+	keyToken := p.curToken
+	if keyToken.Type != token.STRING && keyToken.Type != token.IDENT {
+		p.errors = append(p.errors, fmt.Sprintf("expected pattern key, got %s", keyToken.Type))
+		return pair
+	}
+	pair.Key = keyToken.Literal
+	pair.KeyIsIdentifier = keyToken.Type == token.IDENT
+	if !p.expectPeek(token.COLON) {
+		return pair
+	}
+	p.nextToken()
+	pair.Value = p.parsePattern()
+	return pair
+}
+
+func (p *Parser) parseIdentifier() ast.Expression {
+	return p.currentIdentifier()
+}
+
+func (p *Parser) parseNumberLiteral() ast.Expression {
+	lit := &ast.NumberLiteral{Value: p.curToken.Literal, Start: p.curToken.Pos, Finish: p.curToken.End}
+	return lit
+}
+
+func (p *Parser) parseStringLiteral() ast.Expression {
+	return &ast.StringLiteral{Value: p.curToken.Literal, Start: p.curToken.Pos, Finish: p.curToken.End}
+}
+
+func (p *Parser) parseBooleanLiteral() ast.Expression {
+	return &ast.BooleanLiteral{Value: p.curToken.Type == token.TRUE, Start: p.curToken.Pos, Finish: p.curToken.End}
+}
+
+func (p *Parser) parseNullLiteral() ast.Expression {
+	return &ast.NullLiteral{Start: p.curToken.Pos, Finish: p.curToken.End}
+}
+
+func (p *Parser) parsePrefixExpression() ast.Expression {
+	expr := &ast.PrefixExpression{Operator: p.curToken.Literal, Start: p.curToken.Pos}
+	p.nextToken()
+	expr.Right = p.parseExpression(PREFIX)
+	if expr.Right != nil {
+		expr.Finish = expr.Right.End()
+	} else {
+		expr.Finish = p.curToken.End
+	}
+	return expr
+}
+
+func (p *Parser) parseGroupedExpression() ast.Expression {
+	p.nextToken()
+	exp := p.parseExpression(LOWEST)
+	if !p.expectPeek(token.RPAREN) {
+		return nil
+	}
+	return exp
+}
+
+func (p *Parser) parseArrayLiteral() ast.Expression {
+	array := &ast.ArrayLiteral{Start: p.curToken.Pos}
+	if p.peekTokenIs(token.RBRACKET) {
+		p.nextToken()
+		array.Finish = p.curToken.End
+		return array
+	}
+	p.nextToken()
+	array.Elements = append(array.Elements, p.parseExpression(LOWEST))
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		array.Elements = append(array.Elements, p.parseExpression(LOWEST))
+	}
+	if !p.expectPeek(token.RBRACKET) {
+		return array
+	}
+	array.Finish = p.curToken.End
+	return array
+}
+
+func (p *Parser) parseObjectLiteral() ast.Expression {
+	obj := &ast.ObjectLiteral{Start: p.curToken.Pos}
+	if p.peekTokenIs(token.RBRACE) {
+		p.nextToken()
+		obj.Finish = p.curToken.End
+		return obj
+	}
+	p.nextToken()
+	obj.Pairs = append(obj.Pairs, p.parseObjectPair())
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		obj.Pairs = append(obj.Pairs, p.parseObjectPair())
+	}
+	if !p.expectPeek(token.RBRACE) {
+		return obj
+	}
+	obj.Finish = p.curToken.End
+	return obj
+}
+
+func (p *Parser) parseObjectPair() ast.ObjectPair {
+	pair := ast.ObjectPair{}
+	keyToken := p.curToken
+	if keyToken.Type != token.STRING && keyToken.Type != token.IDENT {
+		p.errors = append(p.errors, fmt.Sprintf("expected object key, got %s", keyToken.Type))
+		return pair
+	}
+	pair.Key = keyToken.Literal
+	pair.KeyIsIdentifier = keyToken.Type == token.IDENT
+	if !p.expectPeek(token.COLON) {
+		return pair
+	}
+	p.nextToken()
+	pair.Value = p.parseExpression(LOWEST)
+	return pair
+}
+
+func (p *Parser) parseAwaitExpression() ast.Expression {
+	expr := &ast.AwaitExpression{Start: p.curToken.Pos}
+	p.nextToken()
+	expr.Expression = p.parseExpression(PREFIX)
+	if expr.Expression != nil {
+		expr.Finish = expr.Expression.End()
+	}
+	return expr
+}
+
+func (p *Parser) parseInfixExpression(left ast.Expression) ast.Expression {
+	expr := &ast.InfixExpression{Left: left, Operator: p.curToken.Literal, Start: left.Pos()}
+	precedence := p.curPrecedence()
+	p.nextToken()
+	expr.Right = p.parseExpression(precedence)
+	if expr.Right != nil {
+		expr.Finish = expr.Right.End()
+	} else {
+		expr.Finish = p.curToken.End
+	}
+	return expr
+}
+
+func (p *Parser) parseElvisExpression(left ast.Expression) ast.Expression {
+	expr := &ast.ElvisExpression{Left: left, Start: left.Pos()}
+	p.nextToken()
+	expr.Right = p.parseExpression(ELVIS - 1)
+	if expr.Right != nil {
+		expr.Finish = expr.Right.End()
+	}
+	return expr
+}
+
+func (p *Parser) parseAssignmentExpression(left ast.Expression) ast.Expression {
+	expr := &ast.AssignmentExpression{Target: left, Start: left.Pos()}
+	precedence := p.curPrecedence()
+	p.nextToken()
+	expr.Value = p.parseExpression(precedence - 1)
+	if expr.Value != nil {
+		expr.Finish = expr.Value.End()
+	}
+	return expr
+}
+
+func (p *Parser) parseCallExpression(function ast.Expression) ast.Expression {
+	exp := &ast.CallExpression{Callee: function, Start: function.Pos()}
+	exp.Arguments = p.parseExpressionList(token.RPAREN)
+	exp.Finish = p.curToken.End
+	return exp
+}
+
+func (p *Parser) parseIndexExpression(left ast.Expression) ast.Expression {
+	exp := &ast.IndexExpression{Collection: left, Start: left.Pos()}
+	p.nextToken()
+	exp.Index = p.parseExpression(LOWEST)
+	if !p.expectPeek(token.RBRACKET) {
+		return exp
+	}
+	exp.Finish = p.curToken.End
+	return exp
+}
+
+func (p *Parser) parseMemberExpression(object ast.Expression) ast.Expression {
+	member := &ast.MemberExpression{Object: object, Optional: p.curToken.Type == token.SAFE_DOT, Start: object.Pos()}
+	if !p.expectPeek(token.IDENT) {
+		return member
+	}
+	member.Property = p.curToken.Literal
+	member.Finish = p.curToken.End
+	return member
+}
+
+func (p *Parser) parseNonNullAssertion(left ast.Expression) ast.Expression {
+	assertion := &ast.NonNullAssertion{Expression: left, Start: left.Pos(), Finish: p.curToken.End}
+	return assertion
+}
+
+func (p *Parser) parseExpressionList(end token.Type) []ast.Expression {
+	list := []ast.Expression{}
+	if p.peekTokenIs(end) {
+		p.nextToken()
+		return list
+	}
+	p.nextToken()
+	list = append(list, p.parseExpression(LOWEST))
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		list = append(list, p.parseExpression(LOWEST))
+	}
+	if !p.expectPeek(end) {
+		return list
+	}
+	return list
+}
+
+func (p *Parser) parseExpression(precedence int) ast.Expression {
+	prefix := p.prefixParseFns[p.curToken.Type]
+	if prefix == nil {
+		p.noPrefixParseFnError(p.curToken.Type)
+		return nil
+	}
+	leftExp := prefix()
+
+	for !p.peekTokenIs(token.SEMICOLON) && precedence < p.peekPrecedence() {
+		infix := p.infixParseFns[p.peekToken.Type]
+		if infix == nil {
+			break
+		}
+		p.nextToken()
+		leftExp = infix(leftExp)
+	}
+
+	return leftExp
+}
+
+func (p *Parser) currentIdentifier() *ast.Identifier {
+	return &ast.Identifier{Name: p.curToken.Literal, Start: p.curToken.Pos, Finish: p.curToken.End}
+}
+
+func (p *Parser) expectPeek(t token.Type) bool {
+	if p.peekTokenIs(t) {
+		p.nextToken()
+		return true
+	}
+	p.peekError(t)
+	return false
+}
+
+func (p *Parser) curTokenIs(t token.Type) bool {
+	return p.curToken.Type == t
+}
+
+func (p *Parser) peekTokenIs(t token.Type) bool {
+	return p.peekToken.Type == t
+}
+
+func (p *Parser) peekPrecedence() int {
+	if p, ok := precedences[p.peekToken.Type]; ok {
+		return p
+	}
+	return LOWEST
+}
+
+func (p *Parser) curPrecedence() int {
+	if p, ok := precedences[p.curToken.Type]; ok {
+		return p
+	}
+	return LOWEST
+}
+
+func (p *Parser) peekError(t token.Type) {
+	msg := fmt.Sprintf("expected next token to be %s, got %s instead", t, p.peekToken.Type)
+	p.errors = append(p.errors, msg)
+}
+
+func (p *Parser) noPrefixParseFnError(t token.Type) {
+	msg := fmt.Sprintf("no prefix parse function for %s found", t)
+	p.errors = append(p.errors, msg)
+}

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -1,0 +1,122 @@
+package token
+
+import "fmt"
+
+// Type represents the type of lexical token.
+type Type string
+
+// Token represents a lexical token with positional metadata.
+type Token struct {
+	Type    Type
+	Literal string
+	Pos     Position
+	End     Position
+}
+
+// Position describes a location within a source file.
+type Position struct {
+	Offset int
+	Line   int
+	Column int
+}
+
+func (p Position) String() string {
+	return fmt.Sprintf("%d:%d", p.Line, p.Column)
+}
+
+const (
+	// Special tokens
+	ILLEGAL Type = "ILLEGAL"
+	EOF     Type = "EOF"
+
+	// Identifiers + literals
+	IDENT  Type = "IDENT"
+	NUMBER Type = "NUMBER"
+	STRING Type = "STRING"
+	TRUE   Type = "TRUE"
+	FALSE  Type = "FALSE"
+	NULL   Type = "NULL"
+
+	// Operators
+	ASSIGN   Type = "="
+	PLUS     Type = "+"
+	MINUS    Type = "-"
+	ASTERISK Type = "*"
+	SLASH    Type = "/"
+	PERCENT  Type = "%"
+	BANG     Type = "!"
+	QUESTION Type = "?"
+	COLON    Type = ":"
+	ELVIS    Type = "?:"
+	SAFE_DOT Type = "?."
+	NON_NULL Type = "!!"
+	EQ       Type = "=="
+	NOT_EQ   Type = "!="
+	LT       Type = "<"
+	LTE      Type = "<="
+	GT       Type = ">"
+	GTE      Type = ">="
+	OR       Type = "||"
+	AND      Type = "&&"
+	ARROW    Type = "=>"
+	IS       Type = "is"
+	NOT_IS   Type = "!is"
+
+	// Delimiters
+	COMMA     Type = ","
+	DOT       Type = "."
+	SEMICOLON Type = ";"
+	LPAREN    Type = "("
+	RPAREN    Type = ")"
+	LBRACE    Type = "{"
+	RBRACE    Type = "}"
+	LBRACKET  Type = "["
+	RBRACKET  Type = "]"
+)
+
+const (
+	// Keywords
+	LET      Type = "let"
+	VAR      Type = "var"
+	FN       Type = "fn"
+	ASYNC    Type = "async"
+	CONTRACT Type = "contract"
+	RETURNS  Type = "returns"
+	CLASS    Type = "class"
+	STRUCT   Type = "struct"
+	ENUM     Type = "enum"
+	MATCH    Type = "match"
+	MODULE   Type = "module"
+	IMPORT   Type = "import"
+	AS       Type = "as"
+	AWAIT    Type = "await"
+)
+
+var keywords = map[string]Type{
+	"let":      LET,
+	"var":      VAR,
+	"fn":       FN,
+	"async":    ASYNC,
+	"contract": CONTRACT,
+	"returns":  RETURNS,
+	"class":    CLASS,
+	"struct":   STRUCT,
+	"enum":     ENUM,
+	"match":    MATCH,
+	"module":   MODULE,
+	"import":   IMPORT,
+	"as":       AS,
+	"true":     TRUE,
+	"false":    FALSE,
+	"null":     NULL,
+	"is":       IS,
+	"await":    AWAIT,
+}
+
+// LookupIdent identifies reserved keywords.
+func LookupIdent(ident string) Type {
+	if tok, ok := keywords[ident]; ok {
+		return tok
+	}
+	return IDENT
+}


### PR DESCRIPTION
## Summary
- add token, lexer, and AST packages to model Selene language constructs with source positions
- implement a Pratt-style parser that handles declarations, expressions, contracts, and patterns
- provide a selene CLI that parses files, optionally dumping tokens, backed by a new Go module

## Testing
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_68df75d68af8832eb5df58e1ac665c75