### PR TITLE
Add package declarations and augmented assignment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,170 @@
+# Selene Language Toolkit
+
+Selene is an experimental programming language frontend implemented in Go. The toolchain now includes a lexer, Pratt-style parser, rich abstract syntax tree (AST) types, and a lightweight tree-walking interpreter. Use it to experiment with language ideas, embed Selene as a scripting language, or extend the runtime with new features.
+
+## Features
+
+- **Tokenization** – The lexer understands Selene keywords, operators, and literals while skipping both line (`// ...`) and block (`/* ... */`) comments with precise source positions.
+- **AST definitions** – The `internal/ast` package models programs, declarations, statements, expressions, patterns, and contracts with positional metadata for diagnostics and tooling.
+- **Pratt parser** – The parser supports modules, variable and function declarations, class/struct/enum definitions, contracts, match statements with pattern destructuring, and rich expression precedence (assignment, Elvis, logical, comparison, arithmetic, calls, indexing, and safe navigation).
+- **Runtime interpreter** – The `internal/runtime` package evaluates Selene programs with lexical scoping, package declarations, modules and imports (including Go-style string imports and aliases), immutable/mutable bindings, first-class functions, user-defined structs/classes/enums, arrays, objects, rich control flow (`if`/`for`/`while`, `return`, `break`, `continue`), Elvis and optional operators, augmented assignment (`+=`, `-=`, `*=`, `/=`, `%=`), pattern matching (including struct and enum cases), and a small standard library (`print`). Function contracts are enforced at call time.
+- **CLI utility** – The `cmd/selene` binary can execute Selene scripts or dump the raw token stream to help debug sources and tooling integrations.
+
+## Installation
+
+Selene is distributed as a standard Go module. With Go 1.21 or newer installed, fetch the dependencies and build the CLI:
+
+```bash
+go mod tidy
+go build ./...
+```
+
+To install the `selene` CLI in your `$GOBIN`, run:
+
+```bash
+go install ./cmd/selene
+```
+
+## Writing your first Selene script
+
+Create `examples/hello.selene` with a few declarations and expressions:
+
+```selene
+// examples/hello.selene
+let greeting: String = "Hello";
+
+fn greet(name: String): String => greeting + ", " + name;
+
+fn main() {
+    print(greet("Selene"));
+}
+
+main();
+```
+
+This script demonstrates immutable `let` bindings, optional type annotations, expression-bodied functions (`=>`), string concatenation, first-class functions, and calling the built-in `print` helper. The final `main();` call drives execution just like a typical scripting entry point.
+
+## Using the CLI
+
+Run a script to execute it:
+
+```bash
+selene examples/hello.selene
+```
+
+Expected output:
+
+```
+Hello, Selene
+```
+
+Inspect the token stream instead of running the program:
+
+```bash
+selene --tokens examples/hello.selene
+```
+
+You will see one token per line, including keywords, identifiers, punctuation, and literals.
+
+## Example gallery
+
+Explore the scripts in the `examples/` directory to get a feel for different Selene features:
+
+- `examples/hello.selene` – introductory greetings, expression-bodied functions, and simple printing.
+- `examples/math.selene` – arithmetic helpers, composing functions, and string interpolation via `+` concatenation.
+- `examples/collections.selene` – arrays, objects, optional property access, and indexing into both arrays and strings.
+- `examples/options.selene` – optional chaining, Elvis defaults, and non-null assertions in practice.
+- `examples/patterns.selene` – destructuring objects with `match` statements and pattern bindings.
+- `examples/recursion.selene` – recursive functions that use `match` clauses for control flow.
+- `examples/control.selene` – `if`/`else` branches, `for`/`while` loops, and the `return`/`break`/`continue` statements.
+- `examples/types.selene` – struct methods, simple classes, enums, and pattern matching on enum cases.
+- `examples/modules.selene` – modules, identifier-based imports, and reusing exported helpers.
+- `examples/packages.selene` – package headers, Go-style string imports, and augmented assignment in action.
+- `examples/contracts.selene` – standalone contract declarations and inline postconditions that validate function results.
+
+Run any script with `selene path/to/script.selene` to see the output directly in your terminal.
+
+## Documentation site
+
+The repository ships with a `docs/` folder that is ready to publish with [GitHub Pages](https://docs.github.com/en/pages). To
+serve the reference documentation:
+
+1. Open the repository settings on GitHub.
+2. Under **Pages**, choose the `main` branch and `/docs` folder as the publishing source.
+3. Save the settings—within a minute GitHub will build and host the static site.
+
+The generated site contains:
+
+- A project overview and quick-start guide.
+- Detailed walkthroughs of Selene syntax and runtime capabilities.
+- A comprehensive [language reference](reference.md) cataloging every construct supported by the lexer and parser.
+- Embedding examples showing how to execute Selene from your own Go programs.
+
+## Embedding Selene as a scripting language
+
+Use the lexer, parser, and runtime packages to execute Selene inside your Go application:
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+
+    "selenelang/internal/lexer"
+    "selenelang/internal/parser"
+    "selenelang/internal/runtime"
+)
+
+func main() {
+    script, err := os.ReadFile("examples/hello.selene")
+    if err != nil {
+        panic(err)
+    }
+
+    l := lexer.New(string(script))
+    p := parser.New(l)
+    program := p.ParseProgram()
+    if errs := p.Errors(); len(errs) > 0 {
+        panic(errs)
+    }
+
+    rt := runtime.New()
+    if _, err := rt.Run(program); err != nil {
+        panic(err)
+    }
+
+    fmt.Println("script executed successfully")
+}
+```
+
+From here you can:
+
+- Extend the runtime with additional built-in functions or host integrations.
+- Compile Selene into another language or bytecode target.
+- Write linters, formatters, or static analyzers that inspect the rich node metadata.
+
+Because every node exposes both `Pos()` and `End()` locations, it is straightforward to produce precise diagnostics or IDE features.
+
+## Project layout
+
+```
+cmd/selene/         CLI entry point
+internal/token/     Token definitions and keyword lookup
+internal/lexer/     Scanner producing tokens with positions
+internal/parser/    Pratt parser producing AST nodes
+internal/ast/       AST node structures used by the parser
+internal/runtime/   Tree-walking interpreter and runtime values
+examples/           Sample Selene sources for experimentation
+```
+
+## Next steps
+
+Selene currently ships with a minimal interpreter focused on core language features. Future work could explore:
+
+- A richer standard library, asynchronous execution primitives, or packaging support for larger projects.
+- A bytecode compiler and virtual machine.
+- Source-to-source transpilers or code generators.
+- Language services like formatting, symbol indexing, or IDE support.
+
+Contributions and experiments are welcome—have fun exploring new language ideas with Selene!

--- a/cmd/selene/main.go
+++ b/cmd/selene/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"selenelang/internal/lexer"
+	"selenelang/internal/parser"
+	"selenelang/internal/runtime"
+	"selenelang/internal/token"
+)
+
+func main() {
+	dumpTokens := flag.Bool("tokens", false, "print the token stream")
+	flag.Parse()
+
+	if flag.NArg() == 0 {
+		fmt.Fprintln(os.Stderr, "usage: selene [--tokens] <file>")
+		os.Exit(1)
+	}
+
+	filename := flag.Arg(0)
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read %s: %v\n", filename, err)
+		os.Exit(1)
+	}
+
+	l := lexer.New(string(content))
+	if *dumpTokens {
+		for tok := l.NextToken(); tok.Type != token.EOF; tok = l.NextToken() {
+			fmt.Printf("%s\t%q\n", tok.Type, tok.Literal)
+		}
+		return
+	}
+
+	l = lexer.New(string(content))
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if errs := p.Errors(); len(errs) > 0 {
+		for _, e := range errs {
+			fmt.Fprintln(os.Stderr, "parse error:", e)
+		}
+		os.Exit(1)
+	}
+
+	rt := runtime.New()
+	if _, err := rt.Run(program); err != nil {
+		fmt.Fprintln(os.Stderr, "runtime error:", err)
+		os.Exit(1)
+	}
+}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,3 @@
+title: Selene Language
+description: Experimental programming language tooling implemented in Go.
+theme: jekyll-theme-minimal

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,0 +1,100 @@
+---
+layout: default
+title: Embedding Selene
+---
+
+# Embedding Selene
+
+Selene's lexer, parser, and interpreter are exposed as Go packages. This guide shows how to execute Selene code from your own
+applications and extend the runtime with custom functionality.
+
+## Running a script from Go
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+
+    "selenelang/internal/lexer"
+    "selenelang/internal/parser"
+    "selenelang/internal/runtime"
+)
+
+func main() {
+    script, err := os.ReadFile("examples/hello.selene")
+    if err != nil {
+        panic(err)
+    }
+
+    l := lexer.New(string(script))
+    p := parser.New(l)
+    program := p.ParseProgram()
+    if errs := p.Errors(); len(errs) > 0 {
+        panic(errs)
+    }
+
+    rt := runtime.New()
+    if _, err := rt.Run(program); err != nil {
+        panic(err)
+    }
+
+    fmt.Println("script executed successfully")
+}
+```
+
+The runtime evaluates statements sequentially and returns the value of the last expression. Errors produced during parsing or
+evaluation bubble back as Go `error` values so you can integrate Selene into larger systems safely.
+
+## Sharing environments
+
+When embedding Selene you can reuse a single runtime to keep global state alive across multiple scripts:
+
+```go
+rt := runtime.New()
+
+for _, path := range []string{"config.selene", "startup.selene"} {
+    if err := runScript(rt, path); err != nil {
+        panic(err)
+    }
+}
+```
+
+Each script receives the same top-level environment, making it easy to build REPLs or plugin systems.
+
+## Adding custom builtins
+
+Expose host functionality by injecting new built-in functions into the runtime environment:
+
+```go
+rt := runtime.New()
+rt.Environment().Set("now", runtime.NewBuiltin("now", func(args []runtime.Value) (runtime.Value, error) {
+    return runtime.NewString(time.Now().Format(time.RFC3339)), nil
+}))
+```
+
+Selene scripts can now call `now()` to retrieve timestamps from the host application.
+Remember to import Go's standard-library `time` package in the host program.
+
+## Handling results
+
+A Selene program returns the last evaluated value. Use this to send structured data back to Go:
+
+```go
+result, err := rt.Run(program)
+if err != nil {
+    return err
+}
+
+fmt.Println("program produced:", result.Inspect())
+```
+
+Objects and arrays map cleanly onto Selene's native composite types, making it straightforward to implement serialization or
+configuration pipelines.
+
+## Embedding tips
+
+- Compile Selene scripts ahead of time if you need to detect syntax errors early.
+- Wrap runtime execution in context-aware cancellation if scripts may run for an extended period.
+- Pair Selene with Go's templating or HTTP packages to build dynamic configuration and scripting environments.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,327 @@
+---
+layout: default
+title: Example Scripts
+---
+
+# Example scripts
+
+Selene ships with runnable scripts that illustrate different language features. Execute any of them with `selene path/to/script.selene`.
+
+## Greeting
+
+**File:** `examples/hello.selene`
+
+Introduces bindings, expression-bodied functions, and printing.
+
+```selene
+let greeting: String = "Hello";
+
+fn greet(name: String): String => greeting + ", " + name;
+
+fn main() {
+    print(greet("Selene"));
+}
+
+main();
+```
+
+## Math utilities
+
+**File:** `examples/math.selene`
+
+Shows how to organize reusable arithmetic helpers and compose functions.
+
+```selene
+let pi: Number = 314159 / 100000;
+
+fn circleArea(radius: Number): Number => radius * radius * pi;
+fn circumference(radius: Number): Number => 2 * pi * radius;
+
+fn report(name: String, radius: Number) {
+    let area = circleArea(radius);
+    let edge = circumference(radius);
+    print(name + " => area=" + area + ", circumference=" + edge);
+}
+
+report("small", 2);
+report("medium", 5);
+report("large", 9);
+```
+
+## Collections and objects
+
+**File:** `examples/collections.selene`
+
+Demonstrates arrays, objects, optional chaining, Elvis expressions, and string indexing.
+
+```selene
+let toolkit = {
+    name: "Selene",
+    version: "0.1.0",
+    features: ["lexer", "parser", "runtime", "docs"],
+    maintainer: null
+};
+
+fn describeToolkit() {
+    print("name => " + toolkit.name);
+    print("version => " + toolkit.version);
+    print("first feature => " + toolkit.features[0]);
+    let maintainer = toolkit.maintainer?.name ?: "Community";
+    print("maintainer => " + maintainer);
+    print("version major => " + toolkit.version[0]);
+}
+
+describeToolkit();
+```
+
+## Optional access patterns
+
+**File:** `examples/options.selene`
+
+Highlights optional chaining, Elvis defaults, and the non-null assertion when navigating nested data.
+
+```selene
+let profile = {
+    name: "Nova",
+    contact: {
+        email: "nova@example.com",
+        address: null
+    }
+};
+
+let email = profile.contact?.email ?: "unknown@selene.dev";
+print("Email: " + email);
+
+let city = profile.contact?.address?.city ?: "Unknown";
+print("City: " + city);
+
+let safeContact = profile.contact!!;
+print("Forced contact email: " + safeContact.email);
+```
+
+## Pattern matching
+
+**File:** `examples/patterns.selene`
+
+Uses `match` statements with object destructuring to branch on structured data.
+
+```selene
+let shapes = [
+    { kind: "circle", radius: 2 },
+    { kind: "square", side: 4 },
+    { kind: "triangle", base: 3, height: 4 }
+];
+
+fn describe(shape: Any) {
+    match shape {
+        { kind: "circle", radius: r } => print("Circle with radius " + r);
+        { kind: "square", side: s } => print("Square with side " + s);
+        other => print("Unknown shape kind " + (other.kind ?: "n/a"));
+    }
+}
+
+print("Cataloging shapes:");
+describe(shapes[0]);
+describe(shapes[1]);
+describe(shapes[2]);
+```
+
+## Recursive helpers
+
+**File:** `examples/recursion.selene`
+
+Demonstrates using `match` clauses to implement recursion-driven control flow without loops.
+
+```selene
+fn factorial(n: Number) {
+    match n {
+        0 => 1;
+        1 => 1;
+        value => value * factorial(value - 1);
+    }
+}
+
+print("Factorial results:");
+print("5! = " + factorial(5));
+print("7! = " + factorial(7));
+```
+
+## Control flow in action
+
+**File:** `examples/control.selene`
+
+Walks through `if`/`else`, `for`/`while`, and the `return`/`break`/`continue` statements.
+
+```selene
+var total = 0;
+
+for (let i = 0; i < 10; i = i + 1) {
+    if i % 2 == 0 {
+        continue;
+    }
+    if i > 7 {
+        break;
+    }
+    total = total + i;
+}
+
+var countdown = 3;
+while countdown > 0 {
+    print("tick", countdown);
+    countdown = countdown - 1;
+}
+
+fn fib(n: Number): Number {
+    if n <= 1 {
+        return n;
+    }
+    return fib(n - 1) + fib(n - 2);
+}
+
+print("total", total);
+print("fib(6)", fib(6));
+
+var attempts = 0;
+while true {
+    attempts = attempts + 1;
+    if attempts == 3 {
+        print("finished after", attempts, "tries");
+        break;
+    }
+}
+```
+
+## Custom types
+
+**File:** `examples/types.selene`
+
+Introduces struct methods, simple classes, enums, and matching on enum cases.
+
+```selene
+struct Point(x: Number, y: Number) {
+    fn describe(): String {
+        return "Point(" + self.x + ", " + self.y + ")";
+    }
+}
+
+class Greeter(name: String) {
+    fn greet(target: String): String {
+        return self.name + ", " + target;
+    }
+}
+
+enum Option {
+    Some(value: Number);
+    None;
+}
+
+let origin = Point(0, 0);
+let greeter = Greeter("Selene");
+let value = Option.Some(41);
+
+print(origin.describe());
+print(greeter.greet("friend"));
+
+match value {
+    Some(v) => print("value + 1 =", v + 1);
+    None => print("no value");
+}
+```
+
+## Modules and imports
+
+**File:** `examples/modules.selene`
+
+Shows how to export helpers from a module and import them elsewhere in the same script using identifier-based paths.
+
+```selene
+module math_utils {
+    fn square(n: Number): Number => n * n;
+    let constants = { tau: 6.28318 };
+}
+
+import math_utils.square;
+import math_utils.constants as consts;
+
+print(square(5));
+print("tau ≈", consts.tau);
+```
+
+## Packages and augmented assignment
+
+**File:** `examples/packages.selene`
+
+Adds a package header to the file, imports a module using Go-style string syntax with an alias, and demonstrates the `+=`, `-=`, `*=`, `/=`, and `%=` operators.
+
+```selene
+package main;
+
+module math_utils {
+    fn increment(n: Number): Number => n + 1;
+    fn triple(n: Number): Number => n * 3;
+}
+
+import utils "math_utils";
+
+fn compute(value: Number): Number {
+    var result = value;
+    result += utils.increment(value);
+    result *= 2;
+    result -= 4;
+    result /= 3;
+    result %= 5;
+    return result;
+}
+
+fn main() {
+    let start = 6;
+    var score = start;
+    score += 2;
+    score *= 3;
+    print("score:", score);
+    print("compute(score):", compute(score));
+}
+
+main();
+```
+
+## Contracts and postconditions
+
+**File:** `examples/contracts.selene`
+
+Combines standalone contract declarations with inline function contracts to validate results.
+
+```selene
+contract validators {
+    fn withinRange(value: Number, min: Number, max: Number): Boolean {
+        return value >= min && value <= max;
+    }
+}
+
+fn clamp(value: Number, min: Number, max: Number): Number
+    contract {
+        returns(result) => result >= min;
+        returns(result) => result <= max;
+    }
+{
+    if value < min {
+        return min;
+    }
+    if value > max {
+        return max;
+    }
+    return value;
+}
+
+let values = [ -5, 3, 42 ];
+for (let i = 0; i < values.length; i = i + 1) {
+    let original = values[i];
+    let clamped = clamp(original, 0, 10);
+    print("clamp(" + original + ") => " + clamped);
+    print("within range? => " + validators.withinRange(clamped, 0, 10));
+}
+```
+
+## Try your own
+
+Create a new file under `examples/` and run it with the CLI. With modules, functions, structs/classes/enums, pattern matching, and imperative loops, Selene gives you enough building blocks to sketch real control flow.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,78 @@
+---
+layout: default
+title: Getting Started
+---
+
+# Getting started
+
+This guide walks through installing the Selene toolchain, running scripts, and navigating the repository.
+
+## Install prerequisites
+
+- [Go 1.21+](https://go.dev/dl/) for building the CLI and embedding Selene.
+- A terminal with access to standard developer tools.
+
+## Fetch the source
+
+Clone the repository and download dependencies:
+
+```bash
+git clone https://github.com/your-user/selenelang.git
+cd selenelang
+go mod tidy
+```
+
+## Build and install the CLI
+
+Use Go to compile the `selene` executable:
+
+```bash
+go build ./...
+```
+
+Install it into your `$GOBIN` so it is accessible anywhere:
+
+```bash
+go install ./cmd/selene
+```
+
+Verify the installation by checking the version banner:
+
+```bash
+selene --help
+```
+
+You should see usage information along with command-line options such as `--tokens`.
+
+## Run your first script
+
+Execute the bundled greeting example:
+
+```bash
+selene examples/hello.selene
+```
+
+You should see output similar to:
+
+```
+Hello, Selene
+```
+
+## Project layout
+
+```
+cmd/selene/         CLI entry point
+internal/token/     Token definitions and keyword lookup
+internal/lexer/     Scanner producing tokens with positions
+internal/parser/    Pratt parser producing AST nodes
+internal/ast/       AST node structures used by the parser
+internal/runtime/   Tree-walking interpreter and runtime values
+examples/           Sample Selene sources for experimentation
+docs/               Documentation site published via GitHub Pages
+```
+
+## Next steps
+
+- Browse the [language tour](language-tour.md) to see the supported syntax and runtime behavior.
+- Consult the [embedding guide](embedding.md) to run Selene inside your own Go projects.
+- Experiment with the scripts in [examples](examples.md) and try extending them with your own functions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,33 @@
+---
+layout: default
+title: Selene Overview
+---
+
+# Selene Overview
+
+Selene is an experimental programming language toolkit implemented in Go. The lexer, parser, and runtime work together to let you
+prototype new language ideas, embed Selene as a scripting language, or analyze Selene source code programmatically.
+
+## Quick links
+
+- [Getting started](getting-started.md) – install the CLI, run scripts, and understand the project layout.
+- [Language tour](language-tour.md) – explore Selene syntax, expression forms, and runtime semantics.
+- [Language reference](reference.md) – browse every construct recognized by the lexer, parser, and runtime.
+- [Embedding guide](embedding.md) – execute Selene code from your own Go applications.
+- [Example scripts](examples.md) – curated walkthroughs of the sample programs included in the repository.
+
+## What you can build today
+
+The current runtime covers expression evaluation, pattern matching, first-class functions, package headers, modules with Go-style imports, user-defined types, and imperative control flow with augmented assignment helpers.
+Combine `if`/`for`/`while`, structs/classes/enums, and pattern-matching to sketch real-world scripts. The standard library remains intentionally tiny so you can experiment with your own runtime helpers.
+
+## Publishing the docs
+
+To publish this site with GitHub Pages:
+
+1. Push the repository to GitHub.
+2. Open **Settings → Pages**.
+3. Choose the `main` branch and the `/docs` folder.
+4. Save your changes and wait for GitHub to build the static site.
+
+Once deployed you will have a hosted reference for the language, examples, and integration guidance.

--- a/docs/language-tour.md
+++ b/docs/language-tour.md
@@ -1,0 +1,234 @@
+---
+layout: default
+title: Language Tour
+---
+
+# Language tour
+
+Selene emphasizes expression-oriented programming with a concise syntax. This tour highlights the features implemented in the
+current interpreter so you can design scripts and DSLs with confidence.
+
+## Literals and bindings
+
+Selene supports numbers, strings, booleans, and null. Bindings are introduced with `let` and are immutable by default:
+
+```selene
+let greeting: String = "Hello";
+let version: Number = 1;
+let debug: Boolean = true;
+let missing = null;
+```
+
+Bindings are looked up dynamically at runtime. Type annotations are optional but help document intent.
+
+## Arithmetic and comparison
+
+Numbers participate in the standard arithmetic and comparison operators:
+
+```selene
+let radius = 5;
+let area = radius * radius * (314159 / 100000);
+let isLarge = area > 50;
+print("area => " + area);
+print("large? " + isLarge);
+```
+
+## Functions
+
+Define functions with `fn`. They close over the lexical environment and may use expression bodies (`=>`) or block bodies:
+
+```selene
+fn double(value: Number): Number => value * 2;
+
+fn describe(name: String, value: Number) {
+    let doubled = double(value);
+    print(name + " => " + doubled);
+}
+
+describe("sample", 21);
+```
+
+Functions return the value of their last expression, or you can use `return` to exit early from a block-bodied function.
+
+## Arrays and objects
+
+Use brackets for arrays and braces for objects. Indexing works on arrays and strings:
+
+```selene
+let features = ["lexer", "parser", "runtime"];
+let project = {
+    name: "Selene",
+    items: features
+};
+
+print(project.name);
+print("first feature => " + project.items[0]);
+print("first letter => " + project.name[0]);
+```
+
+Arrays and strings expose a `length` property for quick sizing.
+
+## Optional chaining and Elvis operator
+
+Member lookups can be made optional with `?.`. Combine this with the Elvis operator `?:` to provide defaults when values are
+null (or become null after an optional access):
+
+```selene
+let config = { name: "Selene", owner: null };
+let owner = config.owner?.name ?: "Unknown";
+print("owner => " + owner);
+```
+
+## Pattern matching
+
+`match` statements provide a flexible way to branch on literals, bind values, and destructure objects. Each clause pattern is tested in order until one matches, and the body of the matching clause produces the statement result:
+
+```selene
+fn describe(shape: Any) {
+    match shape {
+        { kind: "circle", radius: r } => "circle => " + r;
+        { kind: "square", side: s } => "square => " + s;
+        other => "unknown => " + (other.kind ?: "n/a");
+    }
+}
+
+print(describe({ kind: "circle", radius: 3 }));
+```
+
+Patterns may be simple literals (matched by value), identifiers (which bind to the target), object destructuring clauses that recursively match nested shapes, or struct patterns such as `Point(x, y)` that match constructor calls (including enum cases) by position.
+
+## Control flow
+
+Selene offers familiar imperative control flow. Use `if` for branching and `for`/`while` for iteration. `return`, `break`, and `continue` behave as you would expect from other languages. Mutable bindings can take advantage of the augmented assignment operators (`+=`, `-=`, `*=`, `/=`, `%=`) to update values concisely:
+
+```selene
+var total = 0;
+
+for (let i = 0; i < 5; i = i + 1) {
+    if i % 2 == 0 {
+        continue;
+    }
+    total += i;
+}
+
+while total > 4 {
+    total -= 1;
+    if total == 6 {
+        break;
+    }
+}
+
+fn describe(value: Number): String {
+    if value > 4 {
+        return "large";
+    }
+    return "small";
+}
+
+print("summary => " + describe(total));
+```
+
+## Packages, modules, and imports
+
+Start a script with an optional `package` header to label its namespace. Group related helpers inside a `module` and import them elsewhere in the file. Everything defined inside the module body is exported automatically, and you can import exports either by identifier path or via Go-style string syntax:
+
+```selene
+package analytics;
+
+module math_utils {
+    fn square(n: Number): Number => n * n;
+    let constants = { tau: 6.28318 };
+}
+
+import math_utils.square;
+import utils "math_utils";
+
+print(square(5));
+print("tau => " + utils.constants.tau);
+```
+
+## Contracts
+
+Use `contract { ... }` blocks to attach postconditions to functions. Each `returns(condition)` clause evaluates after the
+function body with a special `result` binding that contains the returned value. If a condition is falsy, Selene raises a
+runtime error. Contracts can also capture parameters or other locals from the definition site:
+
+```selene
+fn clamp(value: Number, min: Number, max: Number): Number
+    contract {
+        returns(result) => result >= min;
+        returns(result) => result <= max;
+    }
+{
+    if value < min {
+        return min;
+    }
+    if value > max {
+        return max;
+    }
+    return value;
+}
+
+print("clamp(42, 0, 10) => " + clamp(42, 0, 10));
+```
+
+Separate `contract` declarations create reusable bundles of helpers that can be accessed via dot syntax similar to modules.
+
+## Structs, classes, and enums
+
+Define your own data types with `struct`, `class`, and `enum`. Struct and class constructors behave like functions, and methods gain access to the current instance through `self`:
+
+```selene
+struct Point(x: Number, y: Number) {
+    fn describe(): String {
+        return "Point(" + self.x + ", " + self.y + ")";
+    }
+}
+
+class Greeter(name: String) {
+    fn greet(target: String): String {
+        return self.name + ", " + target;
+    }
+}
+
+enum Option {
+    Some(value: Number);
+    None;
+}
+
+let value = Option.Some(41);
+print(Point(2, 3).describe());
+print(Greeter("Selene").greet("friend"));
+
+match value {
+    Some(v) => print("value + 1 =" + (v + 1));
+    None => print("no value");
+}
+```
+
+## Function application and scoping
+
+Functions capture the environment in which they are defined:
+
+```selene
+let prefix = "[Selene]";
+
+fn makeLogger(label: String) {
+    fn log(message: String) {
+        print(prefix + " " + label + ": " + message);
+    }
+
+    log("logger ready");
+}
+
+makeLogger("demo");
+```
+
+Each function call receives a fresh scope for its parameters, ensuring predictable lexical scoping.
+
+## Limitations and roadmap
+
+The interpreter now covers control flow, modules, and user-defined data types, but it is still intentionally small. `async`
+functions and `await` execute synchronously, property assignment on objects and instances is not yet supported, and the
+standard library only provides `print`. Future iterations aim to grow the builtin ecosystem, add mutation helpers for
+structured data, and experiment with asynchronous execution.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,123 @@
+---
+layout: default
+title: Language Reference
+---
+
+# Selene language reference
+
+This reference catalogs the syntax recognized by the Selene lexer and parser, along with notes on what the runtime executes today. Use it to cross-check constructs while writing scripts or building tooling on top of the Selene frontend.
+
+## Lexical structure
+
+- **Whitespace** – spaces, tabs, and newlines separate tokens but are otherwise ignored.
+- **Comments** – `//` starts a line comment that runs to the end of the line. `/* ... */` forms a block comment and may span multiple lines. Comments are skipped by the lexer and do not nest.
+- **Identifiers** – start with an ASCII letter or underscore and may contain ASCII letters, digits, or underscores. Identifiers are case-sensitive.
+- **Keywords** – `let`, `var`, `fn`, `async`, `contract`, `returns`, `class`, `struct`, `enum`, `match`, `module`, `import`, `as`, `package`, `if`, `else`, `while`, `for`, `return`, `break`, `continue`, `true`, `false`, `null`, `is`, and `await`.
+- **Operators** – arithmetic (`+`, `-`, `*`, `/`, `%`), comparison (`==`, `!=`, `<`, `<=`, `>`, `>=`), logical (`&&`, `||`, `!`), assignment (`=`, `+=`, `-=`, `*=`, `/=`, `%=`), Elvis (`?:`), member access (`.`), optional chaining (`?.`), non-null assertion (`!!`), indexing (`[]`), call application (`()`), and the pattern arrow (`=>`).
+
+## Literals
+
+- **Numbers** – sequences of digits optionally containing a single decimal point (e.g. `42`, `3.14`). All numbers are stored as 64-bit floating point values at runtime.
+- **Strings** – delimited by double quotes and supporting standard escape sequences (e.g. `"\n"`).
+- **Booleans** – the keywords `true` and `false`.
+- **Null** – represented by the keyword `null`.
+- **Arrays** – bracketed collections such as `[1, 2, 3]`. Elements evaluate from left to right.
+- **Objects** – brace-delimited key/value maps like `{ name: "Selene", version: "0.1.0" }`. Keys may be bare identifiers or string literals.
+
+## Declarations
+
+### Variable bindings
+
+- `let name = expression;` creates an immutable binding.
+- `var name = expression;` creates a mutable binding that may be reassigned later with `name = newValue`.
+- Optional type annotations may appear after the identifier: `let count: Number = 3;`. Types are parsed but not enforced by the runtime yet.
+
+### Functions
+
+```
+fn name(parameters) [ : ReturnType ] [async] [contract { ... }] { ... }
+fn name(parameters) [ : ReturnType ] [async] [contract { ... }] => expression;
+```
+
+- Parameters are comma-separated identifiers that may also include type annotations (parsed only).
+- Bodies can be expression-bodied (`=>`) or block-bodied (`{ ... }`). Expression bodies implicitly become the function result.
+- Functions close over the lexical environment in which they are defined.
+- `async` marks a function for future asynchronous execution but currently runs synchronously. Contract clauses are enforced
+  after the function body completes: each `returns(condition)` entry evaluates the optional guard/condition with a `result`
+  binding that contains the function's return value. A falsy condition triggers a runtime error.
+
+### Package headers
+
+- `package identifier;` labels the current file with a package name. The runtime records the package under the `__package__` binding for introspection but otherwise treats it as metadata.
+
+### Modules and imports
+
+```
+module Identifier {
+    // nested declarations and statements
+}
+
+import foo.bar as baz;
+import alias "module_path";
+```
+
+- Modules execute in their own lexical scope and export every binding defined in the body. `import` pulls values from a module (optionally drilling into nested properties) and binds them into the current scope. Provide an alias either before a string literal (`import helpers "math_utils";`) or with an `as` clause (`import math_utils.constants as consts;`). String import paths split on `/` so you can traverse nested exports.
+
+### Classes, structs, enums, and contracts
+
+```
+class Name(params) [ : Super ] { ... }
+struct Name(params) { ... }
+enum Name { CaseOne; CaseTwo(value); }
+contract Name { ... }
+```
+
+- Struct and class declarations introduce callable constructors. Struct instances expose their fields and methods via `self`. Class declarations optionally inherit methods and static values from a superclass. Enum declarations generate constructor functions for each case that produce tagged union values. Contract declarations produce reusable bundles of declarations that can be accessed with dot syntax (similar to modules), and inline function contracts are enforced when the function returns.
+
+## Statements
+
+- **Expression statement** – any expression followed by an optional semicolon. The value of the expression becomes the statement result.
+- **Block** – `{ statement* }` introduces a new lexical scope and returns the value of the last statement inside the block.
+- **If statement** – `if condition { ... } [else statement]` executes the first branch whose condition is truthy. `else if` chains are written as `else` followed by another `if` statement.
+- **While loop** – `while condition { ... }` repeats the body while the condition evaluates to a truthy value.
+- **For loop** – `for (initializer; condition; post) { ... }` executes the initializer once, evaluates the condition before each iteration, and runs the post expression after each iteration.
+- **Match statement** – `match expression { pattern => statement; ... }` evaluates the target expression, tries each pattern in order, and executes the body of the first successful match. The value produced by the body becomes the statement result. If no patterns match, the statement yields `null`.
+- **Return statement** – `return expression?;` exits the innermost function. Without an expression the function returns `null`.
+- **Break/continue** – `break;` exits the nearest loop; `continue;` skips directly to the next iteration.
+
+## Patterns
+
+Selene patterns appear inside `match` statements.
+
+- **Identifier pattern** – `name` binds the matched value to a fresh identifier within the case body.
+- **Literal pattern** – any literal expression (`0`, `"text"`, `true`, `null`, etc.) that matches by value.
+- **Object pattern** – `{ key: subpattern, other: anotherPattern }` destructures object properties recursively. Keys may use identifier or string syntax.
+- **Struct pattern** – `Point(x, y)` matches struct and class instances created by `Point` and binds their positional fields. It also matches enum cases with the same name, binding the case parameters.
+
+## Expressions
+
+- **Primary expressions** – identifiers, literals, array/object literals, and grouped expressions `( ... )`.
+- **Unary operators** – `-expr`, `+expr`, and `!expr`.
+- **Binary operators** – addition, subtraction, multiplication, division, modulo, comparisons, equality, logical `&&`/`||`, and Elvis `?:`.
+- **Assignments** – `name = expression` updates an existing binding created with `var`.
+- **Function calls** – `callee(arg1, arg2)` evaluate the callee then its arguments left to right.
+- **Indexing** – `array[index]` or `string[index]`.
+- **Member access** – `object.property`, optional chaining `object?.property`, and non-null assertions `expression!!`. Arrays and strings expose a read-only `length` property.
+- **Await expression** – the `await` keyword parses and simply evaluates its operand. `async` functions currently execute synchronously.
+
+## Runtime support summary
+
+- The interpreter executes:
+
+- Variable declarations, assignments (including `+=`, `-=`, `*=`, `/=`, `%=`), and lexical scoping.
+- Package declarations, modules, imports (identifier chains or string paths), and nested scopes.
+- Function declarations, first-class closures, expression/block bodies, and inline contracts.
+- Struct, class, and enum constructors with instance methods.
+- Arrays, objects, arithmetic, comparisons, logical operators, Elvis expressions, optional chaining, and non-null assertions.
+- Control flow including `if`/`else`, `for`, `while`, `return`, `break`, and `continue`.
+- Match statements with identifier, literal, object, and struct/enum patterns.
+- The built-in `print` function for console output.
+
+`async` functions and `await` expressions are currently synchronous conveniences; no concurrent runtime is provided yet.
+
+Refer to the [example scripts](examples.md) for runnable demonstrations of the supported features.

--- a/examples/collections.selene
+++ b/examples/collections.selene
@@ -1,0 +1,18 @@
+// Showcase arrays, objects, optional chaining, and indexing.
+let toolkit = {
+    name: "Selene",
+    version: "0.1.0",
+    features: ["lexer", "parser", "runtime", "docs"],
+    maintainer: null
+};
+
+fn describeToolkit() {
+    print("name => " + toolkit.name);
+    print("version => " + toolkit.version);
+    print("first feature => " + toolkit.features[0]);
+    let maintainer = toolkit.maintainer?.name ?: "Community";
+    print("maintainer => " + maintainer);
+    print("version major => " + toolkit.version[0]);
+}
+
+describeToolkit();

--- a/examples/contracts.selene
+++ b/examples/contracts.selene
@@ -1,0 +1,31 @@
+// Demonstrates function contracts and reusable contract declarations.
+
+contract validators {
+    fn withinRange(value: Number, min: Number, max: Number): Boolean {
+        return value >= min && value <= max;
+    }
+}
+
+fn clamp(value: Number, min: Number, max: Number): Number
+    contract {
+        returns(result) => result >= min;
+        returns(result) => result <= max;
+    }
+{
+    if value < min {
+        return min;
+    }
+    if value > max {
+        return max;
+    }
+    return value;
+}
+
+let values = [ -5, 3, 42 ];
+for (let i = 0; i < values.length; i = i + 1) {
+    let original = values[i];
+    let clamped = clamp(original, 0, 10);
+    print("clamp(" + original + ") => " + clamped);
+    let ok = validators.withinRange(clamped, 0, 10);
+    print("within range? => " + ok);
+}

--- a/examples/control.selene
+++ b/examples/control.selene
@@ -1,0 +1,37 @@
+// Demonstrates Selene control flow.
+var total = 0;
+
+for (let i = 0; i < 10; i = i + 1) {
+    if i % 2 == 0 {
+        continue;
+    }
+    if i > 7 {
+        break;
+    }
+    total = total + i;
+}
+
+var countdown = 3;
+while countdown > 0 {
+    print("tick", countdown);
+    countdown = countdown - 1;
+}
+
+fn fib(n: Number): Number {
+    if n <= 1 {
+        return n;
+    }
+    return fib(n - 1) + fib(n - 2);
+}
+
+print("total", total);
+print("fib(6)", fib(6));
+
+var attempts = 0;
+while true {
+    attempts = attempts + 1;
+    if attempts == 3 {
+        print("finished after", attempts, "tries");
+        break;
+    }
+}

--- a/examples/hello.selene
+++ b/examples/hello.selene
@@ -1,0 +1,10 @@
+// examples/hello.selene
+let greeting: String = "Hello";
+
+fn greet(name: String): String => greeting + ", " + name;
+
+fn main() {
+    print(greet("Selene"));
+}
+
+main();

--- a/examples/math.selene
+++ b/examples/math.selene
@@ -1,0 +1,15 @@
+// Demonstrates Selene arithmetic helpers and reusable functions.
+let pi: Number = 314159 / 100000;
+
+fn circleArea(radius: Number): Number => radius * radius * pi;
+fn circumference(radius: Number): Number => 2 * pi * radius;
+
+fn report(name: String, radius: Number) {
+    let area = circleArea(radius);
+    let edge = circumference(radius);
+    print(name + " => area=" + area + ", circumference=" + edge);
+}
+
+report("small", 2);
+report("medium", 5);
+report("large", 9);

--- a/examples/modules.selene
+++ b/examples/modules.selene
@@ -1,0 +1,15 @@
+// Modules and imports in Selene.
+module math_utils {
+    fn square(n: Number): Number => n * n;
+    let constants = { tau: 6.28318 };
+}
+
+import math_utils.square;
+import math_utils.constants as consts;
+
+fn main() {
+    print("square(5) =", square(5));
+    print("tau ≈", consts.tau);
+}
+
+main();

--- a/examples/options.selene
+++ b/examples/options.selene
@@ -1,0 +1,16 @@
+let profile = {
+    name: "Nova",
+    contact: {
+        email: "nova@example.com",
+        address: null
+    }
+};
+
+let email = profile.contact?.email ?: "unknown@selene.dev";
+print("Email: " + email);
+
+let city = profile.contact?.address?.city ?: "Unknown";
+print("City: " + city);
+
+let safeContact = profile.contact!!;
+print("Forced contact email: " + safeContact.email);

--- a/examples/packages.selene
+++ b/examples/packages.selene
@@ -1,0 +1,29 @@
+package main;
+
+module math_utils {
+    fn increment(n: Number): Number => n + 1;
+    fn triple(n: Number): Number => n * 3;
+}
+
+import utils "math_utils";
+
+fn compute(value: Number): Number {
+    var result = value;
+    result += utils.increment(value);
+    result *= 2;
+    result -= 4;
+    result /= 3;
+    result %= 5;
+    return result;
+}
+
+fn main() {
+    let start = 6;
+    var score = start;
+    score += 2;
+    score *= 3;
+    print("score:", score);
+    print("compute(score):", compute(score));
+}
+
+main();

--- a/examples/patterns.selene
+++ b/examples/patterns.selene
@@ -1,0 +1,18 @@
+let shapes = [
+    { kind: "circle", radius: 2 },
+    { kind: "square", side: 4 },
+    { kind: "triangle", base: 3, height: 4 }
+];
+
+fn describe(shape: Any) {
+    match shape {
+        { kind: "circle", radius: r } => print("Circle with radius " + r);
+        { kind: "square", side: s } => print("Square with side " + s);
+        other => print("Unknown shape kind " + (other.kind ?: "n/a"));
+    }
+}
+
+print("Cataloging shapes:");
+describe(shapes[0]);
+describe(shapes[1]);
+describe(shapes[2]);

--- a/examples/recursion.selene
+++ b/examples/recursion.selene
@@ -1,0 +1,11 @@
+fn factorial(n: Number) {
+    match n {
+        0 => 1;
+        1 => 1;
+        value => value * factorial(value - 1);
+    }
+}
+
+print("Factorial results:");
+print("5! = " + factorial(5));
+print("7! = " + factorial(7));

--- a/examples/types.selene
+++ b/examples/types.selene
@@ -1,0 +1,31 @@
+// User-defined data types in Selene.
+struct Point(x: Number, y: Number) {
+    fn describe(): String {
+        return "Point(" + self.x + ", " + self.y + ")";
+    }
+}
+
+class Greeter(name: String) {
+    fn greet(target: String): String {
+        return self.name + ", " + target;
+    }
+}
+
+enum Option {
+    Some(value: Number);
+    None;
+}
+
+let origin = Point(0, 0);
+let offset = Point(3, 4);
+let greeter = Greeter("Selene");
+let value = Option.Some(41);
+
+print(origin.describe());
+print(offset.describe());
+print(greeter.greet("friend"));
+
+match value {
+    Some(v) => print("value + 1 =", v + 1);
+    None => print("no value");
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module selenelang
+
+go 1.24.3

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -1,0 +1,548 @@
+package ast
+
+import "selenelang/internal/token"
+
+type Node interface {
+	Pos() token.Position
+	End() token.Position
+}
+
+type ProgramItem interface {
+	Node
+	programItemNode()
+}
+
+type Program struct {
+	Items  []ProgramItem
+	Start  token.Position
+	Finish token.Position
+}
+
+func (p *Program) Pos() token.Position { return p.Start }
+func (p *Program) End() token.Position { return p.Finish }
+
+type Statement interface {
+	ProgramItem
+	statementNode()
+}
+
+type Expression interface {
+	Node
+	expressionNode()
+}
+
+type Pattern interface {
+	Node
+	patternNode()
+}
+
+type Identifier struct {
+	Name   string
+	Start  token.Position
+	Finish token.Position
+}
+
+func (i *Identifier) Pos() token.Position { return i.Start }
+func (i *Identifier) End() token.Position { return i.Finish }
+func (i *Identifier) expressionNode()     {}
+func (i *Identifier) patternNode()        {}
+
+// Literals
+
+type NumberLiteral struct {
+	Value  string
+	Start  token.Position
+	Finish token.Position
+}
+
+func (n *NumberLiteral) Pos() token.Position { return n.Start }
+func (n *NumberLiteral) End() token.Position { return n.Finish }
+func (n *NumberLiteral) expressionNode()     {}
+func (n *NumberLiteral) patternNode()        {}
+
+type StringLiteral struct {
+	Value  string
+	Start  token.Position
+	Finish token.Position
+}
+
+func (s *StringLiteral) Pos() token.Position { return s.Start }
+func (s *StringLiteral) End() token.Position { return s.Finish }
+func (s *StringLiteral) expressionNode()     {}
+func (s *StringLiteral) patternNode()        {}
+
+type BooleanLiteral struct {
+	Value  bool
+	Start  token.Position
+	Finish token.Position
+}
+
+func (b *BooleanLiteral) Pos() token.Position { return b.Start }
+func (b *BooleanLiteral) End() token.Position { return b.Finish }
+func (b *BooleanLiteral) expressionNode()     {}
+func (b *BooleanLiteral) patternNode()        {}
+
+type NullLiteral struct {
+	Start  token.Position
+	Finish token.Position
+}
+
+func (n *NullLiteral) Pos() token.Position { return n.Start }
+func (n *NullLiteral) End() token.Position { return n.Finish }
+func (n *NullLiteral) expressionNode()     {}
+func (n *NullLiteral) patternNode()        {}
+
+// Composite literals
+
+type ArrayLiteral struct {
+	Elements []Expression
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (a *ArrayLiteral) Pos() token.Position { return a.Start }
+func (a *ArrayLiteral) End() token.Position { return a.Finish }
+func (a *ArrayLiteral) expressionNode()     {}
+
+type ObjectPair struct {
+	Key             string
+	KeyIsIdentifier bool
+	Value           Expression
+}
+
+type ObjectLiteral struct {
+	Pairs  []ObjectPair
+	Start  token.Position
+	Finish token.Position
+}
+
+func (o *ObjectLiteral) Pos() token.Position { return o.Start }
+func (o *ObjectLiteral) End() token.Position { return o.Finish }
+func (o *ObjectLiteral) expressionNode()     {}
+
+// Expressions
+
+type AwaitExpression struct {
+	Expression Expression
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (a *AwaitExpression) Pos() token.Position { return a.Start }
+func (a *AwaitExpression) End() token.Position { return a.Finish }
+func (a *AwaitExpression) expressionNode()     {}
+
+type PrefixExpression struct {
+	Operator string
+	Right    Expression
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (p *PrefixExpression) Pos() token.Position { return p.Start }
+func (p *PrefixExpression) End() token.Position { return p.Finish }
+func (p *PrefixExpression) expressionNode()     {}
+
+type InfixExpression struct {
+	Left     Expression
+	Operator string
+	Right    Expression
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (i *InfixExpression) Pos() token.Position { return i.Start }
+func (i *InfixExpression) End() token.Position { return i.Finish }
+func (i *InfixExpression) expressionNode()     {}
+
+type AssignmentExpression struct {
+	Target   Expression
+	Value    Expression
+	Operator token.Type
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (a *AssignmentExpression) Pos() token.Position { return a.Start }
+func (a *AssignmentExpression) End() token.Position { return a.Finish }
+func (a *AssignmentExpression) expressionNode()     {}
+
+type ElvisExpression struct {
+	Left   Expression
+	Right  Expression
+	Start  token.Position
+	Finish token.Position
+}
+
+func (e *ElvisExpression) Pos() token.Position { return e.Start }
+func (e *ElvisExpression) End() token.Position { return e.Finish }
+func (e *ElvisExpression) expressionNode()     {}
+
+type CallExpression struct {
+	Callee    Expression
+	Arguments []Expression
+	Start     token.Position
+	Finish    token.Position
+}
+
+func (c *CallExpression) Pos() token.Position { return c.Start }
+func (c *CallExpression) End() token.Position { return c.Finish }
+func (c *CallExpression) expressionNode()     {}
+
+type IndexExpression struct {
+	Collection Expression
+	Index      Expression
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (i *IndexExpression) Pos() token.Position { return i.Start }
+func (i *IndexExpression) End() token.Position { return i.Finish }
+func (i *IndexExpression) expressionNode()     {}
+
+type MemberExpression struct {
+	Object   Expression
+	Property string
+	Optional bool
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (m *MemberExpression) Pos() token.Position { return m.Start }
+func (m *MemberExpression) End() token.Position { return m.Finish }
+func (m *MemberExpression) expressionNode()     {}
+
+type NonNullAssertion struct {
+	Expression Expression
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (n *NonNullAssertion) Pos() token.Position { return n.Start }
+func (n *NonNullAssertion) End() token.Position { return n.Finish }
+func (n *NonNullAssertion) expressionNode()     {}
+
+// Statements
+
+type BlockStatement struct {
+	Statements []Statement
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (b *BlockStatement) Pos() token.Position { return b.Start }
+func (b *BlockStatement) End() token.Position { return b.Finish }
+func (b *BlockStatement) statementNode()      {}
+func (b *BlockStatement) programItemNode()    {}
+
+type ExpressionStatement struct {
+	Expression Expression
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (e *ExpressionStatement) Pos() token.Position { return e.Start }
+func (e *ExpressionStatement) End() token.Position { return e.Finish }
+func (e *ExpressionStatement) statementNode()      {}
+func (e *ExpressionStatement) programItemNode()    {}
+
+type IfStatement struct {
+	Condition   Expression
+	Consequence Statement
+	Alternative Statement
+	Start       token.Position
+	Finish      token.Position
+}
+
+func (i *IfStatement) Pos() token.Position { return i.Start }
+func (i *IfStatement) End() token.Position { return i.Finish }
+func (i *IfStatement) statementNode()      {}
+func (i *IfStatement) programItemNode()    {}
+
+type WhileStatement struct {
+	Condition Expression
+	Body      Statement
+	Start     token.Position
+	Finish    token.Position
+}
+
+func (w *WhileStatement) Pos() token.Position { return w.Start }
+func (w *WhileStatement) End() token.Position { return w.Finish }
+func (w *WhileStatement) statementNode()      {}
+func (w *WhileStatement) programItemNode()    {}
+
+type ForStatement struct {
+	Init      Statement
+	Condition Expression
+	Post      Expression
+	Body      Statement
+	Start     token.Position
+	Finish    token.Position
+}
+
+func (f *ForStatement) Pos() token.Position { return f.Start }
+func (f *ForStatement) End() token.Position { return f.Finish }
+func (f *ForStatement) statementNode()      {}
+func (f *ForStatement) programItemNode()    {}
+
+type ReturnStatement struct {
+	Value  Expression
+	Start  token.Position
+	Finish token.Position
+}
+
+func (r *ReturnStatement) Pos() token.Position { return r.Start }
+func (r *ReturnStatement) End() token.Position { return r.Finish }
+func (r *ReturnStatement) statementNode()      {}
+func (r *ReturnStatement) programItemNode()    {}
+
+type BreakStatement struct {
+	Start  token.Position
+	Finish token.Position
+}
+
+func (b *BreakStatement) Pos() token.Position { return b.Start }
+func (b *BreakStatement) End() token.Position { return b.Finish }
+func (b *BreakStatement) statementNode()      {}
+func (b *BreakStatement) programItemNode()    {}
+
+type ContinueStatement struct {
+	Start  token.Position
+	Finish token.Position
+}
+
+func (c *ContinueStatement) Pos() token.Position { return c.Start }
+func (c *ContinueStatement) End() token.Position { return c.Finish }
+func (c *ContinueStatement) statementNode()      {}
+func (c *ContinueStatement) programItemNode()    {}
+
+type VariableDeclaration struct {
+	Mutable bool
+	Name    *Identifier
+	Type    *TypeAnnotation
+	Value   Expression
+	Start   token.Position
+	Finish  token.Position
+}
+
+func (v *VariableDeclaration) Pos() token.Position { return v.Start }
+func (v *VariableDeclaration) End() token.Position { return v.Finish }
+func (v *VariableDeclaration) statementNode()      {}
+func (v *VariableDeclaration) programItemNode()    {}
+
+type Parameter struct {
+	Name *Identifier
+	Type *TypeAnnotation
+}
+
+type TypeAnnotation struct {
+	Name     *Identifier
+	TypeArgs []*TypeAnnotation
+	Nullable bool
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (t *TypeAnnotation) Pos() token.Position { return t.Start }
+func (t *TypeAnnotation) End() token.Position { return t.Finish }
+
+// Functions and contracts
+
+type FunctionDeclaration struct {
+	Name       *Identifier
+	TypeParams []*Identifier
+	Params     []Parameter
+	ReturnType *TypeAnnotation
+	Async      bool
+	Contract   *ContractBlock
+	Body       *BlockStatement
+	BodyExpr   Expression
+	IsExprBody bool
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (f *FunctionDeclaration) Pos() token.Position { return f.Start }
+func (f *FunctionDeclaration) End() token.Position { return f.Finish }
+func (f *FunctionDeclaration) statementNode()      {}
+func (f *FunctionDeclaration) programItemNode()    {}
+
+type ContractBlock struct {
+	Clauses []ContractClause
+	Start   token.Position
+	Finish  token.Position
+}
+
+func (c *ContractBlock) Pos() token.Position { return c.Start }
+func (c *ContractBlock) End() token.Position { return c.Finish }
+
+type ContractClause struct {
+	Guard     Expression
+	Condition Expression
+	Start     token.Position
+	Finish    token.Position
+}
+
+func (c *ContractClause) Pos() token.Position { return c.Start }
+func (c *ContractClause) End() token.Position { return c.Finish }
+
+type ClassDeclaration struct {
+	Name       *Identifier
+	Params     []Parameter
+	SuperClass *Identifier
+	Body       *BlockStatement
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (c *ClassDeclaration) Pos() token.Position { return c.Start }
+func (c *ClassDeclaration) End() token.Position { return c.Finish }
+func (c *ClassDeclaration) statementNode()      {}
+func (c *ClassDeclaration) programItemNode()    {}
+
+type StructDeclaration struct {
+	Name   *Identifier
+	Params []Parameter
+	Body   *BlockStatement
+	Start  token.Position
+	Finish token.Position
+}
+
+func (s *StructDeclaration) Pos() token.Position { return s.Start }
+func (s *StructDeclaration) End() token.Position { return s.Finish }
+func (s *StructDeclaration) statementNode()      {}
+func (s *StructDeclaration) programItemNode()    {}
+
+type EnumDeclaration struct {
+	Name       *Identifier
+	TypeParams []*Identifier
+	Cases      []EnumCase
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (e *EnumDeclaration) Pos() token.Position { return e.Start }
+func (e *EnumDeclaration) End() token.Position { return e.Finish }
+func (e *EnumDeclaration) statementNode()      {}
+func (e *EnumDeclaration) programItemNode()    {}
+
+type EnumCase struct {
+	Name   *Identifier
+	Params []Parameter
+	Start  token.Position
+	Finish token.Position
+}
+
+func (e *EnumCase) Pos() token.Position { return e.Start }
+func (e *EnumCase) End() token.Position { return e.Finish }
+
+type ContractDeclaration struct {
+	Name   *Identifier
+	Body   *BlockStatement
+	Start  token.Position
+	Finish token.Position
+}
+
+func (c *ContractDeclaration) Pos() token.Position { return c.Start }
+func (c *ContractDeclaration) End() token.Position { return c.Finish }
+func (c *ContractDeclaration) statementNode()      {}
+func (c *ContractDeclaration) programItemNode()    {}
+
+type ImportDeclaration struct {
+	Path        []*Identifier
+	PathLiteral string
+	Alias       *Identifier
+	Start       token.Position
+	Finish      token.Position
+}
+
+func (i *ImportDeclaration) Pos() token.Position { return i.Start }
+func (i *ImportDeclaration) End() token.Position { return i.Finish }
+func (i *ImportDeclaration) statementNode()      {}
+func (i *ImportDeclaration) programItemNode()    {}
+
+type PackageDeclaration struct {
+	Name   *Identifier
+	Start  token.Position
+	Finish token.Position
+}
+
+func (p *PackageDeclaration) Pos() token.Position { return p.Start }
+func (p *PackageDeclaration) End() token.Position { return p.Finish }
+func (p *PackageDeclaration) programItemNode()    {}
+
+type ModuleDeclaration struct {
+	Name   *Identifier
+	Body   *BlockStatement
+	Start  token.Position
+	Finish token.Position
+}
+
+func (m *ModuleDeclaration) Pos() token.Position { return m.Start }
+func (m *ModuleDeclaration) End() token.Position { return m.Finish }
+func (m *ModuleDeclaration) programItemNode()    {}
+
+type MatchStatement struct {
+	Value  Expression
+	Cases  []MatchCase
+	Start  token.Position
+	Finish token.Position
+}
+
+func (m *MatchStatement) Pos() token.Position { return m.Start }
+func (m *MatchStatement) End() token.Position { return m.Finish }
+func (m *MatchStatement) statementNode()      {}
+func (m *MatchStatement) programItemNode()    {}
+
+type MatchCase struct {
+	Pattern Pattern
+	Body    Statement
+	Start   token.Position
+	Finish  token.Position
+}
+
+func (m *MatchCase) Pos() token.Position { return m.Start }
+func (m *MatchCase) End() token.Position { return m.Finish }
+
+type PatternPair struct {
+	Key             string
+	KeyIsIdentifier bool
+	Value           Pattern
+}
+
+type ObjectPattern struct {
+	Pairs  []PatternPair
+	Start  token.Position
+	Finish token.Position
+}
+
+func (o *ObjectPattern) Pos() token.Position { return o.Start }
+func (o *ObjectPattern) End() token.Position { return o.Finish }
+func (o *ObjectPattern) patternNode()        {}
+
+type StructPattern struct {
+	Name   *Identifier
+	Fields []Pattern
+	Start  token.Position
+	Finish token.Position
+}
+
+func (s *StructPattern) Pos() token.Position { return s.Start }
+func (s *StructPattern) End() token.Position { return s.Finish }
+func (s *StructPattern) patternNode()        {}
+
+type IdentifierPattern struct {
+	Identifier *Identifier
+}
+
+func (i *IdentifierPattern) Pos() token.Position { return i.Identifier.Pos() }
+func (i *IdentifierPattern) End() token.Position { return i.Identifier.End() }
+func (i *IdentifierPattern) patternNode()        {}
+
+type LiteralPattern struct {
+	Value Expression
+}
+
+func (l *LiteralPattern) Pos() token.Position { return l.Value.Pos() }
+func (l *LiteralPattern) End() token.Position { return l.Value.End() }
+func (l *LiteralPattern) patternNode()        {}

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -1,0 +1,412 @@
+package lexer
+
+import (
+	"strings"
+
+	"selenelang/internal/token"
+)
+
+type Lexer struct {
+	input        []rune
+	position     int
+	readPosition int
+	ch           rune
+	line         int
+	column       int
+}
+
+func New(input string) *Lexer {
+	l := &Lexer{
+		input: []rune(input),
+		line:  1,
+	}
+	l.readRune()
+	return l
+}
+
+func (l *Lexer) NextToken() token.Token {
+	l.skipWhitespaceAndComments()
+
+	startOffset := l.position
+	startLine := l.line
+	startColumn := l.column
+
+	tok := token.Token{
+		Pos: token.Position{Offset: startOffset, Line: startLine, Column: startColumn},
+	}
+
+	switch l.ch {
+	case 0:
+		tok.Type = token.EOF
+		tok.Literal = ""
+		tok.End = tok.Pos
+		return tok
+	case '+':
+		if l.peekRune() == '=' {
+			tok.Type = token.PLUS_ASSIGN
+			tok.Literal = "+="
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.PLUS
+			tok.Literal = "+"
+			l.readRune()
+		}
+	case '-':
+		if l.peekRune() == '=' {
+			tok.Type = token.MINUS_ASSIGN
+			tok.Literal = "-="
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.MINUS
+			tok.Literal = "-"
+			l.readRune()
+		}
+	case '*':
+		if l.peekRune() == '=' {
+			tok.Type = token.STAR_ASSIGN
+			tok.Literal = "*="
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.ASTERISK
+			tok.Literal = "*"
+			l.readRune()
+		}
+	case '%':
+		if l.peekRune() == '=' {
+			tok.Type = token.PERCENT_ASSIGN
+			tok.Literal = "%="
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.PERCENT
+			tok.Literal = "%"
+			l.readRune()
+		}
+	case ',':
+		tok.Type = token.COMMA
+		tok.Literal = ","
+		l.readRune()
+	case ';':
+		tok.Type = token.SEMICOLON
+		tok.Literal = ";"
+		l.readRune()
+	case '(':
+		tok.Type = token.LPAREN
+		tok.Literal = "("
+		l.readRune()
+	case ')':
+		tok.Type = token.RPAREN
+		tok.Literal = ")"
+		l.readRune()
+	case '{':
+		tok.Type = token.LBRACE
+		tok.Literal = "{"
+		l.readRune()
+	case '}':
+		tok.Type = token.RBRACE
+		tok.Literal = "}"
+		l.readRune()
+	case '[':
+		tok.Type = token.LBRACKET
+		tok.Literal = "["
+		l.readRune()
+	case ']':
+		tok.Type = token.RBRACKET
+		tok.Literal = "]"
+		l.readRune()
+	case '.':
+		tok.Type = token.DOT
+		tok.Literal = "."
+		l.readRune()
+	case ':':
+		tok.Type = token.COLON
+		tok.Literal = ":"
+		l.readRune()
+	case '?':
+		switch l.peekRune() {
+		case ':':
+			tok.Type = token.ELVIS
+			tok.Literal = "?:"
+			l.readRune()
+			l.readRune()
+		case '.':
+			tok.Type = token.SAFE_DOT
+			tok.Literal = "?."
+			l.readRune()
+			l.readRune()
+		default:
+			tok.Type = token.QUESTION
+			tok.Literal = "?"
+			l.readRune()
+		}
+	case '!':
+		switch l.peekRune() {
+		case '=':
+			tok.Type = token.NOT_EQ
+			tok.Literal = "!="
+			l.readRune()
+			l.readRune()
+		case '!':
+			tok.Type = token.NON_NULL
+			tok.Literal = "!!"
+			l.readRune()
+			l.readRune()
+		default:
+			if l.peekWord("is") {
+				tok.Type = token.NOT_IS
+				tok.Literal = "!is"
+				l.readRune()
+				l.readRune() // consume 'i'
+				l.readRune() // consume 's'
+			} else {
+				tok.Type = token.BANG
+				tok.Literal = "!"
+				l.readRune()
+			}
+		}
+	case '=':
+		switch l.peekRune() {
+		case '=':
+			tok.Type = token.EQ
+			tok.Literal = "=="
+			l.readRune()
+			l.readRune()
+		case '>':
+			tok.Type = token.ARROW
+			tok.Literal = "=>"
+			l.readRune()
+			l.readRune()
+		default:
+			tok.Type = token.ASSIGN
+			tok.Literal = "="
+			l.readRune()
+		}
+	case '<':
+		if l.peekRune() == '=' {
+			tok.Type = token.LTE
+			tok.Literal = "<="
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.LT
+			tok.Literal = "<"
+			l.readRune()
+		}
+	case '>':
+		if l.peekRune() == '=' {
+			tok.Type = token.GTE
+			tok.Literal = ">="
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.GT
+			tok.Literal = ">"
+			l.readRune()
+		}
+	case '&':
+		if l.peekRune() == '&' {
+			tok.Type = token.AND
+			tok.Literal = "&&"
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.ILLEGAL
+			tok.Literal = string(l.ch)
+			l.readRune()
+		}
+	case '|':
+		if l.peekRune() == '|' {
+			tok.Type = token.OR
+			tok.Literal = "||"
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.ILLEGAL
+			tok.Literal = string(l.ch)
+			l.readRune()
+		}
+	case '/':
+		if l.peekRune() == '=' {
+			tok.Type = token.SLASH_ASSIGN
+			tok.Literal = "/="
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.SLASH
+			tok.Literal = "/"
+			l.readRune()
+		}
+	case '"':
+		lit := l.readString()
+		tok.Type = token.STRING
+		tok.Literal = lit
+	default:
+		if isLetter(l.ch) {
+			literal := l.readIdentifier()
+			tok.Type = token.LookupIdent(literal)
+			tok.Literal = literal
+		} else if isDigit(l.ch) {
+			literal := l.readNumber()
+			tok.Type = token.NUMBER
+			tok.Literal = literal
+		} else {
+			tok.Type = token.ILLEGAL
+			tok.Literal = string(l.ch)
+			l.readRune()
+		}
+	}
+
+	tok.End = token.Position{Offset: l.position, Line: l.line, Column: l.column}
+	return tok
+}
+
+func (l *Lexer) readRune() {
+	if l.readPosition >= len(l.input) {
+		l.position = len(l.input)
+		l.ch = 0
+		return
+	}
+	l.position = l.readPosition
+	l.ch = l.input[l.readPosition]
+	l.readPosition++
+	if l.ch == '\n' {
+		l.line++
+		l.column = 0
+	} else {
+		l.column++
+	}
+}
+
+func (l *Lexer) peekRune() rune {
+	if l.readPosition >= len(l.input) {
+		return 0
+	}
+	return l.input[l.readPosition]
+}
+
+func (l *Lexer) peekWord(word string) bool {
+	if len(word) == 0 {
+		return false
+	}
+	if l.peekRune() != rune(word[0]) {
+		return false
+	}
+	if l.readPosition+len(word) > len(l.input) {
+		return false
+	}
+	for i, r := range word {
+		if l.readPosition+i >= len(l.input) {
+			return false
+		}
+		if l.input[l.readPosition+i] != r {
+			return false
+		}
+	}
+	nextIndex := l.readPosition + len(word)
+	if nextIndex < len(l.input) {
+		next := l.input[nextIndex]
+		if isLetter(next) || isDigit(next) || next == '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func (l *Lexer) readIdentifier() string {
+	start := l.position
+	for isLetter(l.ch) || isDigit(l.ch) || l.ch == '_' {
+		l.readRune()
+	}
+	return string(l.input[start:l.position])
+}
+
+func (l *Lexer) readNumber() string {
+	start := l.position
+	for isDigit(l.ch) {
+		l.readRune()
+	}
+	if l.ch == '.' {
+		dotPos := l.position
+		l.readRune()
+		if isDigit(l.ch) {
+			for isDigit(l.ch) {
+				l.readRune()
+			}
+		} else {
+			l.position = dotPos
+			l.readPosition = dotPos
+			l.ch = '.'
+		}
+	}
+	return string(l.input[start:l.position])
+}
+
+func (l *Lexer) readString() string {
+	l.readRune() // consume opening quote
+	start := l.position
+	for l.ch != '"' && l.ch != 0 {
+		if l.ch == '\\' {
+			l.readRune()
+		}
+		l.readRune()
+	}
+	literal := string(l.input[start:l.position])
+	if l.ch == '"' {
+		l.readRune() // consume closing quote
+	}
+	return literal
+}
+
+func (l *Lexer) skipWhitespaceAndComments() {
+	for {
+		for l.ch == ' ' || l.ch == '\t' || l.ch == '\n' || l.ch == '\r' {
+			l.readRune()
+		}
+		if l.ch == '/' {
+			switch l.peekRune() {
+			case '/':
+				l.consumeLineComment()
+				continue
+			case '*':
+				l.consumeBlockComment()
+				continue
+			}
+		}
+		break
+	}
+}
+
+func (l *Lexer) consumeLineComment() {
+	l.readRune() // consume first '/'
+	l.readRune() // consume second '/'
+	for l.ch != '\n' && l.ch != 0 {
+		l.readRune()
+	}
+}
+
+func (l *Lexer) consumeBlockComment() {
+	l.readRune() // consume first '/'
+	l.readRune() // consume '*'
+	for {
+		if l.ch == 0 {
+			return
+		}
+		if l.ch == '*' && l.peekRune() == '/' {
+			l.readRune()
+			l.readRune()
+			return
+		}
+		l.readRune()
+	}
+}
+
+func isLetter(ch rune) bool {
+	return ch == '_' || strings.ContainsRune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", ch)
+}
+
+func isDigit(ch rune) bool {
+	return ch >= '0' && ch <= '9'
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,0 +1,1212 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+
+	"selenelang/internal/ast"
+	"selenelang/internal/lexer"
+	"selenelang/internal/token"
+)
+
+type (
+	prefixParseFn func() ast.Expression
+	infixParseFn  func(ast.Expression) ast.Expression
+)
+
+type Parser struct {
+	l *lexer.Lexer
+
+	curToken  token.Token
+	peekToken token.Token
+
+	errors []string
+
+	prefixParseFns map[token.Type]prefixParseFn
+	infixParseFns  map[token.Type]infixParseFn
+}
+
+const (
+	_ int = iota
+	LOWEST
+	ASSIGNMENT
+	ELVIS
+	OR
+	AND
+	EQUALITY
+	COMPARISON
+	SUM
+	PRODUCT
+	PREFIX
+	CALL
+)
+
+var precedences = map[token.Type]int{
+	token.ASSIGN:         ASSIGNMENT,
+	token.PLUS_ASSIGN:    ASSIGNMENT,
+	token.MINUS_ASSIGN:   ASSIGNMENT,
+	token.STAR_ASSIGN:    ASSIGNMENT,
+	token.SLASH_ASSIGN:   ASSIGNMENT,
+	token.PERCENT_ASSIGN: ASSIGNMENT,
+	token.ELVIS:          ELVIS,
+	token.OR:             OR,
+	token.AND:            AND,
+	token.EQ:             EQUALITY,
+	token.NOT_EQ:         EQUALITY,
+	token.LT:             COMPARISON,
+	token.LTE:            COMPARISON,
+	token.GT:             COMPARISON,
+	token.GTE:            COMPARISON,
+	token.IS:             COMPARISON,
+	token.NOT_IS:         COMPARISON,
+	token.PLUS:           SUM,
+	token.MINUS:          SUM,
+	token.ASTERISK:       PRODUCT,
+	token.SLASH:          PRODUCT,
+	token.PERCENT:        PRODUCT,
+	token.LPAREN:         CALL,
+	token.LBRACKET:       CALL,
+	token.DOT:            CALL,
+	token.SAFE_DOT:       CALL,
+	token.NON_NULL:       CALL,
+}
+
+func New(l *lexer.Lexer) *Parser {
+	p := &Parser{
+		l:              l,
+		prefixParseFns: make(map[token.Type]prefixParseFn),
+		infixParseFns:  make(map[token.Type]infixParseFn),
+	}
+
+	// Read two tokens so cur and peek are set
+	p.nextToken()
+	p.nextToken()
+
+	p.registerPrefix(token.IDENT, p.parseIdentifier)
+	p.registerPrefix(token.NUMBER, p.parseNumberLiteral)
+	p.registerPrefix(token.STRING, p.parseStringLiteral)
+	p.registerPrefix(token.TRUE, p.parseBooleanLiteral)
+	p.registerPrefix(token.FALSE, p.parseBooleanLiteral)
+	p.registerPrefix(token.NULL, p.parseNullLiteral)
+	p.registerPrefix(token.MINUS, p.parsePrefixExpression)
+	p.registerPrefix(token.BANG, p.parsePrefixExpression)
+	p.registerPrefix(token.LPAREN, p.parseGroupedExpression)
+	p.registerPrefix(token.LBRACKET, p.parseArrayLiteral)
+	p.registerPrefix(token.LBRACE, p.parseObjectLiteral)
+	p.registerPrefix(token.AWAIT, p.parseAwaitExpression)
+
+	p.registerInfix(token.PLUS, p.parseInfixExpression)
+	p.registerInfix(token.MINUS, p.parseInfixExpression)
+	p.registerInfix(token.ASTERISK, p.parseInfixExpression)
+	p.registerInfix(token.SLASH, p.parseInfixExpression)
+	p.registerInfix(token.PERCENT, p.parseInfixExpression)
+	p.registerInfix(token.EQ, p.parseInfixExpression)
+	p.registerInfix(token.NOT_EQ, p.parseInfixExpression)
+	p.registerInfix(token.LT, p.parseInfixExpression)
+	p.registerInfix(token.LTE, p.parseInfixExpression)
+	p.registerInfix(token.GT, p.parseInfixExpression)
+	p.registerInfix(token.GTE, p.parseInfixExpression)
+	p.registerInfix(token.OR, p.parseInfixExpression)
+	p.registerInfix(token.AND, p.parseInfixExpression)
+	p.registerInfix(token.IS, p.parseInfixExpression)
+	p.registerInfix(token.NOT_IS, p.parseInfixExpression)
+	p.registerInfix(token.ELVIS, p.parseElvisExpression)
+	p.registerInfix(token.ASSIGN, p.parseAssignmentExpression)
+	p.registerInfix(token.PLUS_ASSIGN, p.parseAssignmentExpression)
+	p.registerInfix(token.MINUS_ASSIGN, p.parseAssignmentExpression)
+	p.registerInfix(token.STAR_ASSIGN, p.parseAssignmentExpression)
+	p.registerInfix(token.SLASH_ASSIGN, p.parseAssignmentExpression)
+	p.registerInfix(token.PERCENT_ASSIGN, p.parseAssignmentExpression)
+	p.registerInfix(token.LPAREN, p.parseCallExpression)
+	p.registerInfix(token.LBRACKET, p.parseIndexExpression)
+	p.registerInfix(token.DOT, p.parseMemberExpression)
+	p.registerInfix(token.SAFE_DOT, p.parseMemberExpression)
+	p.registerInfix(token.NON_NULL, p.parseNonNullAssertion)
+
+	return p
+}
+
+func (p *Parser) Errors() []string {
+	return p.errors
+}
+
+func (p *Parser) nextToken() {
+	p.curToken = p.peekToken
+	p.peekToken = p.l.NextToken()
+}
+
+func (p *Parser) registerPrefix(t token.Type, fn prefixParseFn) {
+	p.prefixParseFns[t] = fn
+}
+
+func (p *Parser) registerInfix(t token.Type, fn infixParseFn) {
+	p.infixParseFns[t] = fn
+}
+
+func (p *Parser) ParseProgram() *ast.Program {
+	program := &ast.Program{}
+	if p.curToken.Type != token.EOF {
+		program.Start = p.curToken.Pos
+	}
+
+	for p.curToken.Type != token.EOF {
+		var item ast.ProgramItem
+		switch p.curToken.Type {
+		case token.PACKAGE:
+			item = p.parsePackageDeclaration()
+		case token.MODULE:
+			item = p.parseModuleDeclaration()
+		default:
+			stmt := p.parseStatement()
+			if stmt != nil {
+				item = stmt
+			}
+		}
+		if item != nil {
+			program.Items = append(program.Items, item)
+		}
+		p.nextToken()
+	}
+
+	program.Finish = p.curToken.Pos
+	return program
+}
+
+func (p *Parser) parseStatement() ast.Statement {
+	switch p.curToken.Type {
+	case token.LET, token.VAR:
+		return p.parseVariableDeclaration()
+	case token.FN:
+		return p.parseFunctionDeclaration()
+	case token.CLASS:
+		return p.parseClassDeclaration()
+	case token.STRUCT:
+		return p.parseStructDeclaration()
+	case token.ENUM:
+		return p.parseEnumDeclaration()
+	case token.CONTRACT:
+		return p.parseContractDeclaration()
+	case token.IMPORT:
+		return p.parseImportDeclaration()
+	case token.IF:
+		return p.parseIfStatement()
+	case token.WHILE:
+		return p.parseWhileStatement()
+	case token.FOR:
+		return p.parseForStatement()
+	case token.RETURN:
+		return p.parseReturnStatement()
+	case token.BREAK:
+		return p.parseBreakStatement()
+	case token.CONTINUE:
+		return p.parseContinueStatement()
+	case token.MATCH:
+		return p.parseMatchStatement()
+	case token.LBRACE:
+		return p.parseBlockStatement()
+	default:
+		return p.parseExpressionStatement()
+	}
+}
+
+func (p *Parser) parseModuleDeclaration() ast.ProgramItem {
+	module := &ast.ModuleDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	module.Name = p.currentIdentifier()
+
+	if !p.expectPeek(token.LBRACE) {
+		return nil
+	}
+	block := p.parseBlockStatement()
+	module.Body = block
+	if block != nil {
+		module.Finish = block.End()
+	} else {
+		module.Finish = p.curToken.End
+	}
+	return module
+}
+
+func (p *Parser) parsePackageDeclaration() ast.ProgramItem {
+	pkg := &ast.PackageDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	pkg.Name = p.currentIdentifier()
+	pkg.Finish = pkg.Name.End()
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		pkg.Finish = p.curToken.End
+	}
+	return pkg
+}
+
+func (p *Parser) parseVariableDeclaration() ast.Statement {
+	stmt := &ast.VariableDeclaration{Start: p.curToken.Pos, Mutable: p.curToken.Type == token.VAR}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	stmt.Name = p.currentIdentifier()
+
+	if p.peekTokenIs(token.COLON) {
+		p.nextToken()
+		p.nextToken()
+		stmt.Type = p.parseTypeAnnotation()
+	}
+
+	if !p.expectPeek(token.ASSIGN) {
+		return nil
+	}
+
+	p.nextToken()
+	stmt.Value = p.parseExpression(LOWEST)
+	if stmt.Value != nil {
+		stmt.Finish = stmt.Value.End()
+	}
+
+	if !p.expectPeek(token.SEMICOLON) {
+		return stmt
+	}
+	stmt.Finish = p.curToken.End
+	return stmt
+}
+
+func (p *Parser) parseFunctionDeclaration() ast.Statement {
+	fn := &ast.FunctionDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	fn.Name = p.currentIdentifier()
+
+	if p.peekTokenIs(token.LT) {
+		fn.TypeParams = p.parseTypeParameters()
+	}
+
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+	p.nextToken()
+	fn.Params = p.parseParameterList(token.RPAREN)
+
+	if p.peekTokenIs(token.COLON) {
+		p.nextToken()
+		p.nextToken()
+		fn.ReturnType = p.parseTypeAnnotation()
+	}
+
+	if p.peekTokenIs(token.ASYNC) {
+		p.nextToken()
+		fn.Async = true
+	}
+
+	if p.peekTokenIs(token.CONTRACT) {
+		p.nextToken()
+		fn.Contract = p.parseContractBlock()
+	}
+
+	if p.peekTokenIs(token.LBRACE) {
+		p.nextToken()
+		fn.Body = p.parseBlockStatement()
+		if fn.Body != nil {
+			fn.Finish = fn.Body.End()
+		}
+	} else if p.peekTokenIs(token.ASSIGN) || p.peekTokenIs(token.ARROW) {
+		p.nextToken()
+		p.nextToken()
+		fn.IsExprBody = true
+		fn.BodyExpr = p.parseExpression(LOWEST)
+		if fn.BodyExpr != nil {
+			fn.Finish = fn.BodyExpr.End()
+		}
+		if p.peekTokenIs(token.SEMICOLON) {
+			p.nextToken()
+			fn.Finish = p.curToken.End
+		}
+	} else {
+		fn.Finish = p.curToken.End
+	}
+
+	return fn
+}
+
+func (p *Parser) parseClassDeclaration() ast.Statement {
+	class := &ast.ClassDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	class.Name = p.currentIdentifier()
+
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+	p.nextToken()
+	class.Params = p.parseParameterList(token.RPAREN)
+
+	if p.peekTokenIs(token.COLON) {
+		p.nextToken()
+		if !p.expectPeek(token.IDENT) {
+			return class
+		}
+		class.SuperClass = p.currentIdentifier()
+	}
+
+	if p.peekTokenIs(token.LBRACE) {
+		p.nextToken()
+		class.Body = p.parseBlockStatement()
+		if class.Body != nil {
+			class.Finish = class.Body.End()
+		}
+	} else {
+		class.Finish = p.curToken.End
+	}
+	return class
+}
+
+func (p *Parser) parseStructDeclaration() ast.Statement {
+	st := &ast.StructDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	st.Name = p.currentIdentifier()
+
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+	p.nextToken()
+	st.Params = p.parseParameterList(token.RPAREN)
+
+	if p.peekTokenIs(token.LBRACE) {
+		p.nextToken()
+		st.Body = p.parseBlockStatement()
+		if st.Body != nil {
+			st.Finish = st.Body.End()
+		}
+	} else {
+		st.Finish = p.curToken.End
+	}
+	return st
+}
+
+func (p *Parser) parseEnumDeclaration() ast.Statement {
+	enumNode := &ast.EnumDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	enumNode.Name = p.currentIdentifier()
+
+	if p.peekTokenIs(token.LT) {
+		enumNode.TypeParams = p.parseTypeParameters()
+	}
+
+	if !p.expectPeek(token.LBRACE) {
+		return nil
+	}
+	p.nextToken()
+	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
+		caseNode := p.parseEnumCase()
+		if caseNode != nil {
+			enumNode.Cases = append(enumNode.Cases, *caseNode)
+			enumNode.Finish = caseNode.End()
+		}
+		p.nextToken()
+	}
+	if p.curTokenIs(token.RBRACE) {
+		enumNode.Finish = p.curToken.End
+	}
+	return enumNode
+}
+
+func (p *Parser) parseEnumCase() *ast.EnumCase {
+	caseNode := &ast.EnumCase{Start: p.curToken.Pos}
+	if p.curToken.Type != token.IDENT {
+		p.errors = append(p.errors, fmt.Sprintf("expected enum case identifier, got %s", p.curToken.Type))
+		return nil
+	}
+	caseNode.Name = p.currentIdentifier()
+
+	if p.peekTokenIs(token.LPAREN) {
+		p.nextToken()
+		p.nextToken()
+		caseNode.Params = p.parseParameterList(token.RPAREN)
+	}
+
+	if !p.expectPeek(token.SEMICOLON) {
+		return caseNode
+	}
+	caseNode.Finish = p.curToken.End
+	return caseNode
+}
+
+func (p *Parser) parseContractDeclaration() ast.Statement {
+	contract := &ast.ContractDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	contract.Name = p.currentIdentifier()
+
+	if !p.expectPeek(token.LBRACE) {
+		return contract
+	}
+	contract.Body = p.parseBlockStatement()
+	if contract.Body != nil {
+		contract.Finish = contract.Body.End()
+	}
+	return contract
+}
+
+func (p *Parser) parseImportDeclaration() ast.Statement {
+	imp := &ast.ImportDeclaration{Start: p.curToken.Pos}
+
+	if !(p.peekTokenIs(token.STRING) || p.peekTokenIs(token.IDENT)) {
+		p.peekError(token.IDENT)
+		return imp
+	}
+
+	p.nextToken()
+
+	if p.curToken.Type == token.IDENT && p.peekTokenIs(token.STRING) {
+		imp.Alias = p.currentIdentifier()
+		p.nextToken()
+	}
+
+	switch p.curToken.Type {
+	case token.STRING:
+		imp.PathLiteral = p.curToken.Literal
+		segments := strings.Split(imp.PathLiteral, "/")
+		for _, segment := range segments {
+			if segment == "" {
+				continue
+			}
+			imp.Path = append(imp.Path, &ast.Identifier{Name: segment, Start: p.curToken.Pos, Finish: p.curToken.End})
+		}
+	case token.IDENT:
+		imp.Path = append(imp.Path, p.currentIdentifier())
+		for p.peekTokenIs(token.DOT) {
+			p.nextToken()
+			if !p.expectPeek(token.IDENT) {
+				return imp
+			}
+			imp.Path = append(imp.Path, p.currentIdentifier())
+		}
+		if p.peekTokenIs(token.AS) {
+			p.nextToken()
+			if !p.expectPeek(token.IDENT) {
+				return imp
+			}
+			imp.Alias = p.currentIdentifier()
+		}
+	default:
+		p.peekError(token.IDENT)
+		return imp
+	}
+
+	if imp.PathLiteral != "" && imp.Alias == nil && p.peekTokenIs(token.AS) {
+		p.nextToken()
+		if !p.expectPeek(token.IDENT) {
+			return imp
+		}
+		imp.Alias = p.currentIdentifier()
+	}
+
+	if !p.expectPeek(token.SEMICOLON) {
+		return imp
+	}
+	imp.Finish = p.curToken.End
+	return imp
+}
+
+func (p *Parser) parseIfStatement() ast.Statement {
+	stmt := &ast.IfStatement{Start: p.curToken.Pos}
+	p.nextToken()
+	stmt.Condition = p.parseExpression(LOWEST)
+	if stmt.Condition != nil {
+		stmt.Finish = stmt.Condition.End()
+	}
+	if !p.expectPeek(token.LBRACE) {
+		return stmt
+	}
+	stmt.Consequence = p.parseBlockStatement()
+	if stmt.Consequence != nil {
+		stmt.Finish = stmt.Consequence.End()
+	}
+	if p.peekTokenIs(token.ELSE) {
+		p.nextToken()
+		p.nextToken()
+		alt := p.parseStatement()
+		stmt.Alternative = alt
+		if alt != nil {
+			stmt.Finish = alt.End()
+		}
+	}
+	return stmt
+}
+
+func (p *Parser) parseWhileStatement() ast.Statement {
+	stmt := &ast.WhileStatement{Start: p.curToken.Pos}
+	p.nextToken()
+	stmt.Condition = p.parseExpression(LOWEST)
+	if stmt.Condition != nil {
+		stmt.Finish = stmt.Condition.End()
+	}
+	if !p.expectPeek(token.LBRACE) {
+		return stmt
+	}
+	stmt.Body = p.parseBlockStatement()
+	if stmt.Body != nil {
+		stmt.Finish = stmt.Body.End()
+	}
+	return stmt
+}
+
+func (p *Parser) parseForStatement() ast.Statement {
+	stmt := &ast.ForStatement{Start: p.curToken.Pos}
+	if !p.expectPeek(token.LPAREN) {
+		return stmt
+	}
+	p.nextToken()
+
+	if !p.curTokenIs(token.SEMICOLON) {
+		if p.curToken.Type == token.LET || p.curToken.Type == token.VAR {
+			init := p.parseVariableDeclaration()
+			stmt.Init = init
+			if init != nil {
+				stmt.Finish = init.End()
+			}
+		} else {
+			expr := p.parseExpression(LOWEST)
+			if expr != nil {
+				stmt.Init = &ast.ExpressionStatement{Expression: expr, Start: expr.Pos(), Finish: expr.End()}
+				stmt.Finish = expr.End()
+			}
+			if !p.expectPeek(token.SEMICOLON) {
+				return stmt
+			}
+		}
+	}
+
+	if !p.curTokenIs(token.SEMICOLON) {
+		if !p.expectPeek(token.SEMICOLON) {
+			return stmt
+		}
+	}
+
+	p.nextToken()
+	if !p.curTokenIs(token.SEMICOLON) {
+		stmt.Condition = p.parseExpression(LOWEST)
+		if stmt.Condition != nil {
+			stmt.Finish = stmt.Condition.End()
+		}
+		if !p.expectPeek(token.SEMICOLON) {
+			return stmt
+		}
+	}
+
+	p.nextToken()
+	if !p.curTokenIs(token.RPAREN) {
+		stmt.Post = p.parseExpression(LOWEST)
+		if stmt.Post != nil {
+			stmt.Finish = stmt.Post.End()
+		}
+		if !p.expectPeek(token.RPAREN) {
+			return stmt
+		}
+	}
+	if !p.expectPeek(token.LBRACE) {
+		return stmt
+	}
+	stmt.Body = p.parseBlockStatement()
+	if stmt.Body != nil {
+		stmt.Finish = stmt.Body.End()
+	}
+	return stmt
+}
+
+func (p *Parser) parseReturnStatement() ast.Statement {
+	stmt := &ast.ReturnStatement{Start: p.curToken.Pos}
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		stmt.Finish = p.curToken.End
+		return stmt
+	}
+	p.nextToken()
+	stmt.Value = p.parseExpression(LOWEST)
+	if stmt.Value != nil {
+		stmt.Finish = stmt.Value.End()
+	}
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		stmt.Finish = p.curToken.End
+	}
+	return stmt
+}
+
+func (p *Parser) parseBreakStatement() ast.Statement {
+	stmt := &ast.BreakStatement{Start: p.curToken.Pos, Finish: p.curToken.End}
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		stmt.Finish = p.curToken.End
+	}
+	return stmt
+}
+
+func (p *Parser) parseContinueStatement() ast.Statement {
+	stmt := &ast.ContinueStatement{Start: p.curToken.Pos, Finish: p.curToken.End}
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		stmt.Finish = p.curToken.End
+	}
+	return stmt
+}
+
+func (p *Parser) parseMatchStatement() ast.Statement {
+	match := &ast.MatchStatement{Start: p.curToken.Pos}
+	p.nextToken()
+	match.Value = p.parseExpression(LOWEST)
+	if !p.expectPeek(token.LBRACE) {
+		return match
+	}
+	p.nextToken()
+	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
+		caseNode := p.parseMatchCase()
+		if caseNode != nil {
+			match.Cases = append(match.Cases, *caseNode)
+			match.Finish = caseNode.End()
+		}
+		p.nextToken()
+	}
+	if p.curTokenIs(token.RBRACE) {
+		match.Finish = p.curToken.End
+	}
+	return match
+}
+
+func (p *Parser) parseMatchCase() *ast.MatchCase {
+	caseNode := &ast.MatchCase{Start: p.curToken.Pos}
+	pattern := p.parsePattern()
+	caseNode.Pattern = pattern
+
+	if !p.expectPeek(token.ARROW) {
+		return caseNode
+	}
+	p.nextToken()
+	body := p.parseStatement()
+	caseNode.Body = body
+	if body != nil {
+		caseNode.Finish = body.End()
+	}
+	return caseNode
+}
+
+func (p *Parser) parseBlockStatement() *ast.BlockStatement {
+	block := &ast.BlockStatement{Start: p.curToken.Pos}
+	p.nextToken()
+	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
+		stmt := p.parseStatement()
+		if stmt != nil {
+			block.Statements = append(block.Statements, stmt)
+		}
+		p.nextToken()
+	}
+	block.Finish = p.curToken.End
+	return block
+}
+
+func (p *Parser) parseExpressionStatement() ast.Statement {
+	stmt := &ast.ExpressionStatement{Start: p.curToken.Pos}
+	stmt.Expression = p.parseExpression(LOWEST)
+	if stmt.Expression != nil {
+		stmt.Finish = stmt.Expression.End()
+	}
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		stmt.Finish = p.curToken.End
+	}
+	return stmt
+}
+
+func (p *Parser) parseTypeParameters() []*ast.Identifier {
+	params := []*ast.Identifier{}
+	if !p.expectPeek(token.LT) {
+		return params
+	}
+	if !p.expectPeek(token.IDENT) {
+		return params
+	}
+	params = append(params, p.currentIdentifier())
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		if !p.expectPeek(token.IDENT) {
+			return params
+		}
+		params = append(params, p.currentIdentifier())
+	}
+	if !p.expectPeek(token.GT) {
+		return params
+	}
+	return params
+}
+
+func (p *Parser) parseParameterList(end token.Type) []ast.Parameter {
+	params := []ast.Parameter{}
+	if p.curTokenIs(end) {
+		return params
+	}
+	param := p.parseParameter()
+	params = append(params, param)
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		params = append(params, p.parseParameter())
+	}
+	if !p.expectPeek(end) {
+		return params
+	}
+	return params
+}
+
+func (p *Parser) parseParameter() ast.Parameter {
+	param := ast.Parameter{}
+	if p.curToken.Type != token.IDENT {
+		p.errors = append(p.errors, fmt.Sprintf("expected parameter name, got %s", p.curToken.Type))
+		return param
+	}
+	param.Name = p.currentIdentifier()
+	if !p.expectPeek(token.COLON) {
+		return param
+	}
+	p.nextToken()
+	param.Type = p.parseTypeAnnotation()
+	return param
+}
+
+func (p *Parser) parseTypeAnnotation() *ast.TypeAnnotation {
+	if p.curToken.Type != token.IDENT {
+		p.errors = append(p.errors, fmt.Sprintf("expected type identifier, got %s", p.curToken.Type))
+		return nil
+	}
+	typeNode := &ast.TypeAnnotation{Start: p.curToken.Pos}
+	typeNode.Name = p.currentIdentifier()
+
+	if p.peekTokenIs(token.LT) {
+		p.nextToken()
+		p.nextToken()
+		if arg := p.parseTypeAnnotation(); arg != nil {
+			typeNode.TypeArgs = append(typeNode.TypeArgs, arg)
+		}
+		for p.peekTokenIs(token.COMMA) {
+			p.nextToken()
+			p.nextToken()
+			if arg := p.parseTypeAnnotation(); arg != nil {
+				typeNode.TypeArgs = append(typeNode.TypeArgs, arg)
+			}
+		}
+		if !p.expectPeek(token.GT) {
+			return typeNode
+		}
+	}
+
+	if p.peekTokenIs(token.QUESTION) {
+		p.nextToken()
+		typeNode.Nullable = true
+	}
+
+	typeNode.Finish = p.curToken.End
+	return typeNode
+}
+
+func (p *Parser) parseContractBlock() *ast.ContractBlock {
+	block := &ast.ContractBlock{Start: p.curToken.Pos}
+	if !p.expectPeek(token.LBRACE) {
+		return block
+	}
+	p.nextToken()
+	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
+		clause := p.parseContractClause()
+		if clause != nil {
+			block.Clauses = append(block.Clauses, *clause)
+		}
+		p.nextToken()
+	}
+	block.Finish = p.curToken.End
+	return block
+}
+
+func (p *Parser) parseContractClause() *ast.ContractClause {
+	clause := &ast.ContractClause{Start: p.curToken.Pos}
+	if p.curToken.Type != token.RETURNS {
+		p.errors = append(p.errors, fmt.Sprintf("expected 'returns' in contract clause, got %s", p.curToken.Type))
+		return nil
+	}
+	if !p.expectPeek(token.LPAREN) {
+		return clause
+	}
+	if !p.peekTokenIs(token.RPAREN) {
+		p.nextToken()
+		clause.Guard = p.parseExpression(LOWEST)
+	}
+	if !p.expectPeek(token.RPAREN) {
+		return clause
+	}
+	if !p.expectPeek(token.ARROW) {
+		return clause
+	}
+	p.nextToken()
+	clause.Condition = p.parseExpression(LOWEST)
+	if !p.expectPeek(token.SEMICOLON) {
+		return clause
+	}
+	clause.Finish = p.curToken.End
+	return clause
+}
+
+func (p *Parser) parsePattern() ast.Pattern {
+	switch p.curToken.Type {
+	case token.NUMBER:
+		node := &ast.NumberLiteral{Value: p.curToken.Literal, Start: p.curToken.Pos, Finish: p.curToken.End}
+		return &ast.LiteralPattern{Value: node}
+	case token.STRING:
+		node := &ast.StringLiteral{Value: p.curToken.Literal, Start: p.curToken.Pos, Finish: p.curToken.End}
+		return &ast.LiteralPattern{Value: node}
+	case token.TRUE, token.FALSE:
+		node := &ast.BooleanLiteral{Value: p.curToken.Type == token.TRUE, Start: p.curToken.Pos, Finish: p.curToken.End}
+		return &ast.LiteralPattern{Value: node}
+	case token.NULL:
+		node := &ast.NullLiteral{Start: p.curToken.Pos, Finish: p.curToken.End}
+		return &ast.LiteralPattern{Value: node}
+	case token.IDENT:
+		ident := p.currentIdentifier()
+		if p.peekTokenIs(token.LPAREN) {
+			return p.parseStructPattern(ident)
+		}
+		return &ast.IdentifierPattern{Identifier: ident}
+	case token.LBRACE:
+		return p.parseObjectPattern()
+	default:
+		p.errors = append(p.errors, fmt.Sprintf("unexpected token in pattern: %s", p.curToken.Type))
+		return nil
+	}
+}
+
+func (p *Parser) parseStructPattern(name *ast.Identifier) ast.Pattern {
+	pattern := &ast.StructPattern{Name: name, Start: name.Pos()}
+	if !p.expectPeek(token.LPAREN) {
+		return pattern
+	}
+	p.nextToken()
+	if p.curTokenIs(token.RPAREN) {
+		pattern.Finish = p.curToken.End
+		return pattern
+	}
+	pattern.Fields = append(pattern.Fields, p.parsePattern())
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		pattern.Fields = append(pattern.Fields, p.parsePattern())
+	}
+	if !p.expectPeek(token.RPAREN) {
+		return pattern
+	}
+	pattern.Finish = p.curToken.End
+	return pattern
+}
+
+func (p *Parser) parseObjectPattern() ast.Pattern {
+	pattern := &ast.ObjectPattern{Start: p.curToken.Pos}
+	p.nextToken()
+	if p.curTokenIs(token.RBRACE) {
+		pattern.Finish = p.curToken.End
+		return pattern
+	}
+	pattern.Pairs = append(pattern.Pairs, p.parsePatternPair())
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		pattern.Pairs = append(pattern.Pairs, p.parsePatternPair())
+	}
+	if !p.expectPeek(token.RBRACE) {
+		return pattern
+	}
+	pattern.Finish = p.curToken.End
+	return pattern
+}
+
+func (p *Parser) parsePatternPair() ast.PatternPair {
+	pair := ast.PatternPair{}
+	keyToken := p.curToken
+	if keyToken.Type != token.STRING && keyToken.Type != token.IDENT {
+		p.errors = append(p.errors, fmt.Sprintf("expected pattern key, got %s", keyToken.Type))
+		return pair
+	}
+	pair.Key = keyToken.Literal
+	pair.KeyIsIdentifier = keyToken.Type == token.IDENT
+	if !p.expectPeek(token.COLON) {
+		return pair
+	}
+	p.nextToken()
+	pair.Value = p.parsePattern()
+	return pair
+}
+
+func (p *Parser) parseIdentifier() ast.Expression {
+	return p.currentIdentifier()
+}
+
+func (p *Parser) parseNumberLiteral() ast.Expression {
+	lit := &ast.NumberLiteral{Value: p.curToken.Literal, Start: p.curToken.Pos, Finish: p.curToken.End}
+	return lit
+}
+
+func (p *Parser) parseStringLiteral() ast.Expression {
+	return &ast.StringLiteral{Value: p.curToken.Literal, Start: p.curToken.Pos, Finish: p.curToken.End}
+}
+
+func (p *Parser) parseBooleanLiteral() ast.Expression {
+	return &ast.BooleanLiteral{Value: p.curToken.Type == token.TRUE, Start: p.curToken.Pos, Finish: p.curToken.End}
+}
+
+func (p *Parser) parseNullLiteral() ast.Expression {
+	return &ast.NullLiteral{Start: p.curToken.Pos, Finish: p.curToken.End}
+}
+
+func (p *Parser) parsePrefixExpression() ast.Expression {
+	expr := &ast.PrefixExpression{Operator: p.curToken.Literal, Start: p.curToken.Pos}
+	p.nextToken()
+	expr.Right = p.parseExpression(PREFIX)
+	if expr.Right != nil {
+		expr.Finish = expr.Right.End()
+	} else {
+		expr.Finish = p.curToken.End
+	}
+	return expr
+}
+
+func (p *Parser) parseGroupedExpression() ast.Expression {
+	p.nextToken()
+	exp := p.parseExpression(LOWEST)
+	if !p.expectPeek(token.RPAREN) {
+		return nil
+	}
+	return exp
+}
+
+func (p *Parser) parseArrayLiteral() ast.Expression {
+	array := &ast.ArrayLiteral{Start: p.curToken.Pos}
+	if p.peekTokenIs(token.RBRACKET) {
+		p.nextToken()
+		array.Finish = p.curToken.End
+		return array
+	}
+	p.nextToken()
+	array.Elements = append(array.Elements, p.parseExpression(LOWEST))
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		array.Elements = append(array.Elements, p.parseExpression(LOWEST))
+	}
+	if !p.expectPeek(token.RBRACKET) {
+		return array
+	}
+	array.Finish = p.curToken.End
+	return array
+}
+
+func (p *Parser) parseObjectLiteral() ast.Expression {
+	obj := &ast.ObjectLiteral{Start: p.curToken.Pos}
+	if p.peekTokenIs(token.RBRACE) {
+		p.nextToken()
+		obj.Finish = p.curToken.End
+		return obj
+	}
+	p.nextToken()
+	obj.Pairs = append(obj.Pairs, p.parseObjectPair())
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		obj.Pairs = append(obj.Pairs, p.parseObjectPair())
+	}
+	if !p.expectPeek(token.RBRACE) {
+		return obj
+	}
+	obj.Finish = p.curToken.End
+	return obj
+}
+
+func (p *Parser) parseObjectPair() ast.ObjectPair {
+	pair := ast.ObjectPair{}
+	keyToken := p.curToken
+	if keyToken.Type != token.STRING && keyToken.Type != token.IDENT {
+		p.errors = append(p.errors, fmt.Sprintf("expected object key, got %s", keyToken.Type))
+		return pair
+	}
+	pair.Key = keyToken.Literal
+	pair.KeyIsIdentifier = keyToken.Type == token.IDENT
+	if !p.expectPeek(token.COLON) {
+		return pair
+	}
+	p.nextToken()
+	pair.Value = p.parseExpression(LOWEST)
+	return pair
+}
+
+func (p *Parser) parseAwaitExpression() ast.Expression {
+	expr := &ast.AwaitExpression{Start: p.curToken.Pos}
+	p.nextToken()
+	expr.Expression = p.parseExpression(PREFIX)
+	if expr.Expression != nil {
+		expr.Finish = expr.Expression.End()
+	}
+	return expr
+}
+
+func (p *Parser) parseInfixExpression(left ast.Expression) ast.Expression {
+	expr := &ast.InfixExpression{Left: left, Operator: p.curToken.Literal, Start: left.Pos()}
+	precedence := p.curPrecedence()
+	p.nextToken()
+	expr.Right = p.parseExpression(precedence)
+	if expr.Right != nil {
+		expr.Finish = expr.Right.End()
+	} else {
+		expr.Finish = p.curToken.End
+	}
+	return expr
+}
+
+func (p *Parser) parseElvisExpression(left ast.Expression) ast.Expression {
+	expr := &ast.ElvisExpression{Left: left, Start: left.Pos()}
+	p.nextToken()
+	expr.Right = p.parseExpression(ELVIS - 1)
+	if expr.Right != nil {
+		expr.Finish = expr.Right.End()
+	}
+	return expr
+}
+
+func (p *Parser) parseAssignmentExpression(left ast.Expression) ast.Expression {
+	expr := &ast.AssignmentExpression{Target: left, Operator: p.curToken.Type, Start: left.Pos()}
+	precedence := p.curPrecedence()
+	p.nextToken()
+	expr.Value = p.parseExpression(precedence - 1)
+	if expr.Value != nil {
+		expr.Finish = expr.Value.End()
+	}
+	return expr
+}
+
+func (p *Parser) parseCallExpression(function ast.Expression) ast.Expression {
+	exp := &ast.CallExpression{Callee: function, Start: function.Pos()}
+	exp.Arguments = p.parseExpressionList(token.RPAREN)
+	exp.Finish = p.curToken.End
+	return exp
+}
+
+func (p *Parser) parseIndexExpression(left ast.Expression) ast.Expression {
+	exp := &ast.IndexExpression{Collection: left, Start: left.Pos()}
+	p.nextToken()
+	exp.Index = p.parseExpression(LOWEST)
+	if !p.expectPeek(token.RBRACKET) {
+		return exp
+	}
+	exp.Finish = p.curToken.End
+	return exp
+}
+
+func (p *Parser) parseMemberExpression(object ast.Expression) ast.Expression {
+	member := &ast.MemberExpression{Object: object, Optional: p.curToken.Type == token.SAFE_DOT, Start: object.Pos()}
+	if !p.expectPeek(token.IDENT) {
+		return member
+	}
+	member.Property = p.curToken.Literal
+	member.Finish = p.curToken.End
+	return member
+}
+
+func (p *Parser) parseNonNullAssertion(left ast.Expression) ast.Expression {
+	assertion := &ast.NonNullAssertion{Expression: left, Start: left.Pos(), Finish: p.curToken.End}
+	return assertion
+}
+
+func (p *Parser) parseExpressionList(end token.Type) []ast.Expression {
+	list := []ast.Expression{}
+	if p.peekTokenIs(end) {
+		p.nextToken()
+		return list
+	}
+	p.nextToken()
+	list = append(list, p.parseExpression(LOWEST))
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		list = append(list, p.parseExpression(LOWEST))
+	}
+	if !p.expectPeek(end) {
+		return list
+	}
+	return list
+}
+
+func (p *Parser) parseExpression(precedence int) ast.Expression {
+	prefix := p.prefixParseFns[p.curToken.Type]
+	if prefix == nil {
+		p.noPrefixParseFnError(p.curToken.Type)
+		return nil
+	}
+	leftExp := prefix()
+
+	for !p.peekTokenIs(token.SEMICOLON) && precedence < p.peekPrecedence() {
+		infix := p.infixParseFns[p.peekToken.Type]
+		if infix == nil {
+			break
+		}
+		p.nextToken()
+		leftExp = infix(leftExp)
+	}
+
+	return leftExp
+}
+
+func (p *Parser) currentIdentifier() *ast.Identifier {
+	return &ast.Identifier{Name: p.curToken.Literal, Start: p.curToken.Pos, Finish: p.curToken.End}
+}
+
+func (p *Parser) expectPeek(t token.Type) bool {
+	if p.peekTokenIs(t) {
+		p.nextToken()
+		return true
+	}
+	p.peekError(t)
+	return false
+}
+
+func (p *Parser) curTokenIs(t token.Type) bool {
+	return p.curToken.Type == t
+}
+
+func (p *Parser) peekTokenIs(t token.Type) bool {
+	return p.peekToken.Type == t
+}
+
+func (p *Parser) peekPrecedence() int {
+	if p, ok := precedences[p.peekToken.Type]; ok {
+		return p
+	}
+	return LOWEST
+}
+
+func (p *Parser) curPrecedence() int {
+	if p, ok := precedences[p.curToken.Type]; ok {
+		return p
+	}
+	return LOWEST
+}
+
+func (p *Parser) peekError(t token.Type) {
+	msg := fmt.Sprintf("expected next token to be %s, got %s instead", t, p.peekToken.Type)
+	p.errors = append(p.errors, msg)
+}
+
+func (p *Parser) noPrefixParseFnError(t token.Type) {
+	msg := fmt.Sprintf("no prefix parse function for %s found", t)
+	p.errors = append(p.errors, msg)
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1,0 +1,1542 @@
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+
+	"selenelang/internal/ast"
+	"selenelang/internal/token"
+)
+
+type Value interface {
+	Type() string
+	Inspect() string
+}
+
+type Number struct {
+	Value float64
+}
+
+func (n *Number) Type() string    { return "Number" }
+func (n *Number) Inspect() string { return strconv.FormatFloat(n.Value, 'f', -1, 64) }
+
+type String struct {
+	Value string
+}
+
+func (s *String) Type() string    { return "String" }
+func (s *String) Inspect() string { return s.Value }
+
+type Boolean struct {
+	Value bool
+}
+
+func (b *Boolean) Type() string { return "Boolean" }
+func (b *Boolean) Inspect() string {
+	if b.Value {
+		return "true"
+	}
+	return "false"
+}
+
+type Null struct{}
+
+func (n *Null) Type() string    { return "Null" }
+func (n *Null) Inspect() string { return "null" }
+
+var NullValue Value = &Null{}
+var TrueValue Value = &Boolean{Value: true}
+var FalseValue Value = &Boolean{Value: false}
+
+type Array struct {
+	Elements []Value
+}
+
+func (a *Array) Type() string { return "Array" }
+func (a *Array) Inspect() string {
+	parts := make([]string, len(a.Elements))
+	for i, el := range a.Elements {
+		parts[i] = el.Inspect()
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+type Object struct {
+	Properties map[string]Value
+}
+
+func (o *Object) Type() string { return "Object" }
+func (o *Object) Inspect() string {
+	parts := make([]string, 0, len(o.Properties))
+	for k, v := range o.Properties {
+		parts = append(parts, fmt.Sprintf("%s: %s", k, v.Inspect()))
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+type Module struct {
+	Name    string
+	Exports map[string]Value
+}
+
+func (m *Module) Type() string { return "Module" }
+func (m *Module) Inspect() string {
+	keys := make([]string, 0, len(m.Exports))
+	for k := range m.Exports {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = k
+	}
+	return fmt.Sprintf("<module %s [%s]>", m.Name, strings.Join(parts, ", "))
+}
+
+type StructType struct {
+	Name    string
+	Fields  []string
+	Methods map[string]*Function
+	Static  map[string]Value
+}
+
+func (s *StructType) Type() string { return "Struct" }
+func (s *StructType) Inspect() string {
+	return fmt.Sprintf("<struct %s>", s.Name)
+}
+
+type StructInstance struct {
+	Definition *StructType
+	Fields     map[string]Value
+}
+
+func (s *StructInstance) Type() string { return s.Definition.Name }
+func (s *StructInstance) Inspect() string {
+	keys := make([]string, 0, len(s.Fields))
+	for k := range s.Fields {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = fmt.Sprintf("%s: %s", k, s.Fields[k].Inspect())
+	}
+	return fmt.Sprintf("%s{%s}", s.Definition.Name, strings.Join(parts, ", "))
+}
+
+type ClassType struct {
+	Name    string
+	Fields  []string
+	Methods map[string]*Function
+	Static  map[string]Value
+	Super   *ClassType
+}
+
+func (c *ClassType) Type() string { return "Class" }
+func (c *ClassType) Inspect() string {
+	return fmt.Sprintf("<class %s>", c.Name)
+}
+
+type ClassInstance struct {
+	Definition *ClassType
+	Fields     map[string]Value
+}
+
+func (c *ClassInstance) Type() string { return c.Definition.Name }
+func (c *ClassInstance) Inspect() string {
+	keys := make([]string, 0, len(c.Fields))
+	for k := range c.Fields {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = fmt.Sprintf("%s: %s", k, c.Fields[k].Inspect())
+	}
+	return fmt.Sprintf("%s{%s}", c.Definition.Name, strings.Join(parts, ", "))
+}
+
+func (c *ClassType) lookupMethod(name string) (*Function, bool) {
+	if c == nil {
+		return nil, false
+	}
+	if fn, ok := c.Methods[name]; ok {
+		return fn, true
+	}
+	if c.Super != nil {
+		return c.Super.lookupMethod(name)
+	}
+	return nil, false
+}
+
+func (c *ClassType) lookupStatic(name string) (Value, bool) {
+	if c == nil {
+		return nil, false
+	}
+	if val, ok := c.Static[name]; ok {
+		return val, true
+	}
+	if c.Super != nil {
+		return c.Super.lookupStatic(name)
+	}
+	return nil, false
+}
+
+type EnumType struct {
+	Name         string
+	Cases        map[string][]string
+	Constructors map[string]Value
+}
+
+func (e *EnumType) Type() string { return "Enum" }
+func (e *EnumType) Inspect() string {
+	keys := make([]string, 0, len(e.Cases))
+	for k := range e.Cases {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return fmt.Sprintf("<enum %s [%s]>", e.Name, strings.Join(keys, ", "))
+}
+
+type EnumInstance struct {
+	Enum   *EnumType
+	Case   string
+	Fields map[string]Value
+	Order  []string
+}
+
+func (e *EnumInstance) Type() string { return e.Enum.Name }
+func (e *EnumInstance) Inspect() string {
+	args := make([]string, len(e.Order))
+	for i, name := range e.Order {
+		args[i] = e.Fields[name].Inspect()
+	}
+	if len(args) == 0 {
+		return fmt.Sprintf("%s.%s", e.Enum.Name, e.Case)
+	}
+	return fmt.Sprintf("%s.%s(%s)", e.Enum.Name, e.Case, strings.Join(args, ", "))
+}
+
+type Contract struct {
+	Name    string
+	Exports map[string]Value
+}
+
+func (c *Contract) Type() string { return "Contract" }
+func (c *Contract) Inspect() string {
+	keys := make([]string, 0, len(c.Exports))
+	for k := range c.Exports {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return fmt.Sprintf("<contract %s [%s]>", c.Name, strings.Join(keys, ", "))
+}
+
+type BuiltinFunction func(args []Value) (Value, error)
+
+type Function struct {
+	Declaration *ast.FunctionDeclaration
+	Env         *Environment
+	Builtin     BuiltinFunction
+	Name        string
+}
+
+func (f *Function) Type() string { return "Function" }
+func (f *Function) Inspect() string {
+	if f.Name != "" {
+		return fmt.Sprintf("<fn %s>", f.Name)
+	}
+	return "<fn>"
+}
+
+func NewBoolean(v bool) Value {
+	if v {
+		return TrueValue
+	}
+	return FalseValue
+}
+
+func NewNumber(v float64) Value { return &Number{Value: v} }
+func NewString(v string) Value  { return &String{Value: v} }
+
+func NewBuiltin(name string, fn BuiltinFunction) Value {
+	return &Function{Name: name, Builtin: fn}
+}
+
+type returnSignal struct {
+	value Value
+}
+
+func (r *returnSignal) Error() string { return "return" }
+
+type breakSignal struct{}
+
+func (b *breakSignal) Error() string { return "break" }
+
+type continueSignal struct{}
+
+func (c *continueSignal) Error() string { return "continue" }
+
+type Environment struct {
+	store map[string]Value
+	outer *Environment
+}
+
+func NewEnvironment() *Environment {
+	return &Environment{store: make(map[string]Value)}
+}
+
+func NewEnclosedEnvironment(outer *Environment) *Environment {
+	env := NewEnvironment()
+	env.outer = outer
+	return env
+}
+
+func (e *Environment) Get(name string) (Value, bool) {
+	if val, ok := e.store[name]; ok {
+		return val, true
+	}
+	if e.outer != nil {
+		return e.outer.Get(name)
+	}
+	return nil, false
+}
+
+func (e *Environment) Set(name string, val Value) Value {
+	e.store[name] = val
+	return val
+}
+
+func (e *Environment) Assign(name string, val Value) (Value, error) {
+	if _, ok := e.store[name]; ok {
+		e.store[name] = val
+		return val, nil
+	}
+	if e.outer != nil {
+		return e.outer.Assign(name, val)
+	}
+	return nil, fmt.Errorf("undefined variable %s", name)
+}
+
+type Runtime struct {
+	env *Environment
+}
+
+func New() *Runtime {
+	env := NewEnvironment()
+	env.Set("print", NewBuiltin("print", builtinPrint))
+	return &Runtime{env: env}
+}
+
+func (r *Runtime) Environment() *Environment {
+	return r.env
+}
+
+func (r *Runtime) Run(program *ast.Program) (Value, error) {
+	return evalProgram(program, r.env)
+}
+
+func evalProgram(program *ast.Program, env *Environment) (Value, error) {
+	result := NullValue
+	for _, item := range program.Items {
+		switch node := item.(type) {
+		case ast.Statement:
+			val, err := evalStatement(node, env)
+			if err != nil {
+				if _, ok := err.(*returnSignal); ok {
+					return nil, errors.New("return outside of function")
+				}
+				if _, ok := err.(*breakSignal); ok {
+					return nil, errors.New("break outside of loop")
+				}
+				if _, ok := err.(*continueSignal); ok {
+					return nil, errors.New("continue outside of loop")
+				}
+				return nil, err
+			}
+			result = val
+		case *ast.ModuleDeclaration:
+			val, err := evalModuleDeclaration(node, env)
+			if err != nil {
+				return nil, err
+			}
+			result = val
+		case *ast.PackageDeclaration:
+			if node.Name != nil {
+				env.Set("__package__", NewString(node.Name.Name))
+			}
+			result = NullValue
+		default:
+			return nil, fmt.Errorf("runtime does not support top-level %T", item)
+		}
+	}
+	return result, nil
+}
+
+func evalStatement(stmt ast.Statement, env *Environment) (Value, error) {
+	switch node := stmt.(type) {
+	case *ast.ExpressionStatement:
+		if node.Expression == nil {
+			return NullValue, nil
+		}
+		return evalExpression(node.Expression, env)
+	case *ast.VariableDeclaration:
+		var val Value = NullValue
+		var err error
+		if node.Value != nil {
+			val, err = evalExpression(node.Value, env)
+			if err != nil {
+				return nil, err
+			}
+		}
+		env.Set(node.Name.Name, val)
+		return val, nil
+	case *ast.FunctionDeclaration:
+		fn := &Function{Declaration: node, Env: env, Name: node.Name.Name}
+		env.Set(node.Name.Name, fn)
+		return fn, nil
+	case *ast.ImportDeclaration:
+		return evalImportDeclaration(node, env)
+	case *ast.StructDeclaration:
+		return evalStructDeclaration(node, env)
+	case *ast.ClassDeclaration:
+		return evalClassDeclaration(node, env)
+	case *ast.EnumDeclaration:
+		return evalEnumDeclaration(node, env)
+	case *ast.ContractDeclaration:
+		return evalContractDeclaration(node, env)
+	case *ast.BlockStatement:
+		blockEnv := NewEnclosedEnvironment(env)
+		return evalBlock(node, blockEnv)
+	case *ast.MatchStatement:
+		return evalMatchStatement(node, env)
+	case *ast.IfStatement:
+		return evalIfStatement(node, env)
+	case *ast.WhileStatement:
+		return evalWhileStatement(node, env)
+	case *ast.ForStatement:
+		return evalForStatement(node, env)
+	case *ast.ReturnStatement:
+		var val Value = NullValue
+		var err error
+		if node.Value != nil {
+			val, err = evalExpression(node.Value, env)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return val, &returnSignal{value: val}
+	case *ast.BreakStatement:
+		return NullValue, &breakSignal{}
+	case *ast.ContinueStatement:
+		return NullValue, &continueSignal{}
+	default:
+		return nil, fmt.Errorf("runtime does not support statement %T", stmt)
+	}
+}
+
+func evalBlock(block *ast.BlockStatement, env *Environment) (Value, error) {
+	result := NullValue
+	for _, stmt := range block.Statements {
+		val, err := evalStatement(stmt, env)
+		if err != nil {
+			switch sig := err.(type) {
+			case *returnSignal:
+				return sig.value, err
+			case *breakSignal, *continueSignal:
+				return NullValue, err
+			default:
+				return nil, err
+			}
+		}
+		result = val
+	}
+	return result, nil
+}
+
+func evalIfStatement(stmt *ast.IfStatement, env *Environment) (Value, error) {
+	if stmt.Condition == nil {
+		return NullValue, nil
+	}
+	condition, err := evalExpression(stmt.Condition, env)
+	if err != nil {
+		return nil, err
+	}
+	if isTruthy(condition) {
+		if stmt.Consequence == nil {
+			return NullValue, nil
+		}
+		return evalStatement(stmt.Consequence, env)
+	}
+	if stmt.Alternative != nil {
+		return evalStatement(stmt.Alternative, env)
+	}
+	return NullValue, nil
+}
+
+func evalWhileStatement(stmt *ast.WhileStatement, env *Environment) (Value, error) {
+	result := NullValue
+	for {
+		if stmt.Condition != nil {
+			cond, err := evalExpression(stmt.Condition, env)
+			if err != nil {
+				return nil, err
+			}
+			if !isTruthy(cond) {
+				break
+			}
+		}
+		if stmt.Body == nil {
+			continue
+		}
+		val, err := evalStatement(stmt.Body, env)
+		if err != nil {
+			switch sig := err.(type) {
+			case *breakSignal:
+				return result, nil
+			case *continueSignal:
+				continue
+			case *returnSignal:
+				return sig.value, err
+			default:
+				return nil, err
+			}
+		}
+		result = val
+	}
+	return result, nil
+}
+
+func evalForStatement(stmt *ast.ForStatement, env *Environment) (Value, error) {
+	loopEnv := NewEnclosedEnvironment(env)
+	if stmt.Init != nil {
+		if _, err := evalStatement(stmt.Init, loopEnv); err != nil {
+			switch err.(type) {
+			case *returnSignal:
+				return nil, errors.New("return not allowed in for initializer")
+			case *breakSignal, *continueSignal:
+				return nil, errors.New("loop control not allowed in for initializer")
+			default:
+				return nil, err
+			}
+		}
+	}
+
+	result := NullValue
+	for {
+		if stmt.Condition != nil {
+			cond, err := evalExpression(stmt.Condition, loopEnv)
+			if err != nil {
+				return nil, err
+			}
+			if !isTruthy(cond) {
+				break
+			}
+		}
+
+		if stmt.Body != nil {
+			val, err := evalStatement(stmt.Body, loopEnv)
+			if err != nil {
+				switch sig := err.(type) {
+				case *breakSignal:
+					return result, nil
+				case *continueSignal:
+					if stmt.Post != nil {
+						if _, err := evalExpression(stmt.Post, loopEnv); err != nil {
+							return nil, err
+						}
+					}
+					continue
+				case *returnSignal:
+					return sig.value, err
+				default:
+					return nil, err
+				}
+			} else {
+				result = val
+			}
+		}
+
+		if stmt.Post != nil {
+			if _, err := evalExpression(stmt.Post, loopEnv); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func evalExpression(expr ast.Expression, env *Environment) (Value, error) {
+	switch node := expr.(type) {
+	case *ast.Identifier:
+		if val, ok := env.Get(node.Name); ok {
+			return val, nil
+		}
+		return nil, fmt.Errorf("undefined identifier %s", node.Name)
+	case *ast.NumberLiteral:
+		num, err := strconv.ParseFloat(node.Value, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid number literal %q", node.Value)
+		}
+		return NewNumber(num), nil
+	case *ast.StringLiteral:
+		return NewString(node.Value), nil
+	case *ast.BooleanLiteral:
+		return NewBoolean(node.Value), nil
+	case *ast.NullLiteral:
+		return NullValue, nil
+	case *ast.AwaitExpression:
+		return evalExpression(node.Expression, env)
+	case *ast.PrefixExpression:
+		right, err := evalExpression(node.Right, env)
+		if err != nil {
+			return nil, err
+		}
+		return evalPrefixExpression(node.Operator, right)
+	case *ast.InfixExpression:
+		left, err := evalExpression(node.Left, env)
+		if err != nil {
+			return nil, err
+		}
+		right, err := evalExpression(node.Right, env)
+		if err != nil {
+			return nil, err
+		}
+		return evalInfixExpression(node.Operator, left, right)
+	case *ast.AssignmentExpression:
+		ident, ok := node.Target.(*ast.Identifier)
+		if !ok {
+			return nil, errors.New("only simple identifiers can be assigned")
+		}
+		right, err := evalExpression(node.Value, env)
+		if err != nil {
+			return nil, err
+		}
+		var result Value
+		if node.Operator == token.ASSIGN {
+			result = right
+		} else {
+			current, ok := env.Get(ident.Name)
+			if !ok {
+				return nil, fmt.Errorf("undefined variable %s", ident.Name)
+			}
+			result, err = applyAugmentedAssignment(node.Operator, current, right)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if _, err := env.Assign(ident.Name, result); err != nil {
+			return nil, err
+		}
+		return result, nil
+	case *ast.CallExpression:
+		callee, err := evalExpression(node.Callee, env)
+		if err != nil {
+			return nil, err
+		}
+		args := make([]Value, 0, len(node.Arguments))
+		for _, arg := range node.Arguments {
+			val, err := evalExpression(arg, env)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, val)
+		}
+		return applyFunction(callee, args)
+	case *ast.ArrayLiteral:
+		elements := make([]Value, 0, len(node.Elements))
+		for _, el := range node.Elements {
+			val, err := evalExpression(el, env)
+			if err != nil {
+				return nil, err
+			}
+			elements = append(elements, val)
+		}
+		return &Array{Elements: elements}, nil
+	case *ast.ObjectLiteral:
+		props := make(map[string]Value)
+		for _, pair := range node.Pairs {
+			val, err := evalExpression(pair.Value, env)
+			if err != nil {
+				return nil, err
+			}
+			props[pair.Key] = val
+		}
+		return &Object{Properties: props}, nil
+	case *ast.IndexExpression:
+		collection, err := evalExpression(node.Collection, env)
+		if err != nil {
+			return nil, err
+		}
+		indexVal, err := evalExpression(node.Index, env)
+		if err != nil {
+			return nil, err
+		}
+		return evalIndexExpression(collection, indexVal)
+	case *ast.MemberExpression:
+		objectVal, err := evalExpression(node.Object, env)
+		if err != nil {
+			return nil, err
+		}
+		return evalMemberExpression(objectVal, node.Property, node.Optional)
+	case *ast.ElvisExpression:
+		left, err := evalExpression(node.Left, env)
+		if err != nil {
+			return nil, err
+		}
+		if isTruthy(left) {
+			return left, nil
+		}
+		return evalExpression(node.Right, env)
+	case *ast.NonNullAssertion:
+		val, err := evalExpression(node.Expression, env)
+		if err != nil {
+			return nil, err
+		}
+		if _, isNull := val.(*Null); isNull {
+			return nil, errors.New("encountered null in non-null assertion")
+		}
+		return val, nil
+	default:
+		return nil, fmt.Errorf("runtime does not support expression %T", expr)
+	}
+}
+
+func evalPrefixExpression(operator string, right Value) (Value, error) {
+	switch operator {
+	case "!":
+		return NewBoolean(!isTruthy(right)), nil
+	case "-":
+		number, ok := right.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("cannot negate %s", right.Type())
+		}
+		return NewNumber(-number.Value), nil
+	case "+":
+		if number, ok := right.(*Number); ok {
+			return NewNumber(+number.Value), nil
+		}
+		return nil, fmt.Errorf("cannot apply unary + to %s", right.Type())
+	default:
+		return nil, fmt.Errorf("unknown prefix operator %s", operator)
+	}
+}
+
+func evalInfixExpression(operator string, left, right Value) (Value, error) {
+	switch operator {
+	case "+":
+		switch l := left.(type) {
+		case *Number:
+			r, ok := right.(*Number)
+			if !ok {
+				return nil, fmt.Errorf("cannot add %s to Number", right.Type())
+			}
+			return NewNumber(l.Value + r.Value), nil
+		case *String:
+			return NewString(l.Value + toString(right)), nil
+		default:
+			if _, ok := right.(*String); ok {
+				return NewString(toString(left) + toString(right)), nil
+			}
+			return nil, fmt.Errorf("operator + not supported for %s", left.Type())
+		}
+	case "-":
+		l, ok := left.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("operator - not supported for %s", left.Type())
+		}
+		r, ok := right.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("operator - requires Number on right, got %s", right.Type())
+		}
+		return NewNumber(l.Value - r.Value), nil
+	case "*":
+		l, ok := left.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("operator * not supported for %s", left.Type())
+		}
+		r, ok := right.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("operator * requires Number on right, got %s", right.Type())
+		}
+		return NewNumber(l.Value * r.Value), nil
+	case "/":
+		l, ok := left.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("operator / not supported for %s", left.Type())
+		}
+		r, ok := right.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("operator / requires Number on right, got %s", right.Type())
+		}
+		if r.Value == 0 {
+			return nil, errors.New("division by zero")
+		}
+		return NewNumber(l.Value / r.Value), nil
+	case "%":
+		l, ok := left.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("operator %% not supported for %s", left.Type())
+		}
+		r, ok := right.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("operator %% requires Number on right, got %s", right.Type())
+		}
+		if r.Value == 0 {
+			return nil, errors.New("modulo by zero")
+		}
+		return NewNumber(math.Mod(l.Value, r.Value)), nil
+	case "==":
+		return NewBoolean(equals(left, right)), nil
+	case "!=":
+		return NewBoolean(!equals(left, right)), nil
+	case "<":
+		return compareNumbers(operator, left, right)
+	case "<=":
+		return compareNumbers(operator, left, right)
+	case ">":
+		return compareNumbers(operator, left, right)
+	case ">=":
+		return compareNumbers(operator, left, right)
+	case "&&":
+		return NewBoolean(isTruthy(left) && isTruthy(right)), nil
+	case "||":
+		return NewBoolean(isTruthy(left) || isTruthy(right)), nil
+	default:
+		return nil, fmt.Errorf("unknown infix operator %s", operator)
+	}
+}
+
+func applyAugmentedAssignment(op token.Type, current, update Value) (Value, error) {
+	switch op {
+	case token.PLUS_ASSIGN:
+		return evalInfixExpression("+", current, update)
+	case token.MINUS_ASSIGN:
+		return evalInfixExpression("-", current, update)
+	case token.STAR_ASSIGN:
+		return evalInfixExpression("*", current, update)
+	case token.SLASH_ASSIGN:
+		return evalInfixExpression("/", current, update)
+	case token.PERCENT_ASSIGN:
+		return evalInfixExpression("%", current, update)
+	default:
+		return nil, fmt.Errorf("unsupported assignment operator %s", op)
+	}
+}
+
+func compareNumbers(operator string, left, right Value) (Value, error) {
+	l, ok := left.(*Number)
+	if !ok {
+		return nil, fmt.Errorf("operator %s requires Number operands", operator)
+	}
+	r, ok := right.(*Number)
+	if !ok {
+		return nil, fmt.Errorf("operator %s requires Number operands", operator)
+	}
+
+	switch operator {
+	case "<":
+		return NewBoolean(l.Value < r.Value), nil
+	case "<=":
+		return NewBoolean(l.Value <= r.Value), nil
+	case ">":
+		return NewBoolean(l.Value > r.Value), nil
+	case ">=":
+		return NewBoolean(l.Value >= r.Value), nil
+	default:
+		return nil, fmt.Errorf("unknown comparison operator %s", operator)
+	}
+}
+
+func equals(left, right Value) bool {
+	switch l := left.(type) {
+	case *Null:
+		_, isNull := right.(*Null)
+		return isNull
+	case *Boolean:
+		r, ok := right.(*Boolean)
+		return ok && l.Value == r.Value
+	case *Number:
+		r, ok := right.(*Number)
+		return ok && l.Value == r.Value
+	case *String:
+		r, ok := right.(*String)
+		return ok && l.Value == r.Value
+	default:
+		return left == right
+	}
+}
+
+func toString(val Value) string {
+	return val.Inspect()
+}
+
+func isTruthy(val Value) bool {
+	switch v := val.(type) {
+	case *Null:
+		return false
+	case *Boolean:
+		return v.Value
+	case *Number:
+		return v.Value != 0
+	case *String:
+		return v.Value != ""
+	case *Array:
+		return len(v.Elements) > 0
+	case *Object:
+		return len(v.Properties) > 0
+	default:
+		return val != nil
+	}
+}
+
+func evalIndexExpression(collection, index Value) (Value, error) {
+	switch col := collection.(type) {
+	case *Array:
+		num, ok := index.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("array index must be Number, got %s", index.Type())
+		}
+		idx := int(num.Value)
+		if float64(idx) != num.Value {
+			return nil, errors.New("array index must be integer")
+		}
+		if idx < 0 || idx >= len(col.Elements) {
+			return nil, fmt.Errorf("array index %d out of range", idx)
+		}
+		return col.Elements[idx], nil
+	case *String:
+		num, ok := index.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("string index must be Number, got %s", index.Type())
+		}
+		idx := int(num.Value)
+		if float64(idx) != num.Value {
+			return nil, errors.New("string index must be integer")
+		}
+		runes := []rune(col.Value)
+		if idx < 0 || idx >= len(runes) {
+			return nil, fmt.Errorf("string index %d out of range", idx)
+		}
+		return NewString(string(runes[idx])), nil
+	default:
+		return nil, fmt.Errorf("cannot index into %s", collection.Type())
+	}
+}
+
+func evalMemberExpression(object Value, property string, optional bool) (Value, error) {
+	val, ok, err := getProperty(object, property)
+	if err != nil {
+		if optional {
+			return NullValue, nil
+		}
+		return nil, err
+	}
+	if !ok {
+		if optional {
+			return NullValue, nil
+		}
+		return nil, fmt.Errorf("%s has no property %s", object.Type(), property)
+	}
+	return val, nil
+}
+
+func evalMatchStatement(match *ast.MatchStatement, env *Environment) (Value, error) {
+	target, err := evalExpression(match.Value, env)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, clause := range match.Cases {
+		caseEnv := NewEnclosedEnvironment(env)
+		matched, err := matchPattern(clause.Pattern, target, caseEnv)
+		if err != nil {
+			return nil, err
+		}
+		if !matched {
+			continue
+		}
+		if clause.Body == nil {
+			return NullValue, nil
+		}
+		return evalStatement(clause.Body, caseEnv)
+	}
+
+	return NullValue, nil
+}
+
+func matchPattern(pattern ast.Pattern, value Value, env *Environment) (bool, error) {
+	switch p := pattern.(type) {
+	case *ast.IdentifierPattern:
+		if p.Identifier == nil {
+			return false, nil
+		}
+		env.Set(p.Identifier.Name, value)
+		return true, nil
+	case *ast.LiteralPattern:
+		expected, err := evalExpression(p.Value, env)
+		if err != nil {
+			return false, err
+		}
+		return equals(expected, value), nil
+	case *ast.ObjectPattern:
+		obj, ok := value.(*Object)
+		if !ok {
+			return false, nil
+		}
+		return matchObjectPattern(p, obj, env)
+	case *ast.StructPattern:
+		return matchStructPatternRuntime(p, value, env)
+	default:
+		return false, fmt.Errorf("unsupported pattern %T", pattern)
+	}
+}
+
+func matchObjectPattern(pattern *ast.ObjectPattern, value *Object, env *Environment) (bool, error) {
+	for _, pair := range pattern.Pairs {
+		propName := pair.Key
+		if pair.KeyIsIdentifier {
+			propName = pair.Key
+		}
+		propVal, ok := value.Properties[propName]
+		if !ok {
+			return false, nil
+		}
+
+		matched, err := matchPattern(pair.Value, propVal, env)
+		if err != nil {
+			return false, err
+		}
+		if !matched {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func matchStructPatternRuntime(pattern *ast.StructPattern, value Value, env *Environment) (bool, error) {
+	if pattern.Name == nil {
+		return false, nil
+	}
+	switch v := value.(type) {
+	case *StructInstance:
+		if v.Definition == nil || v.Definition.Name != pattern.Name.Name {
+			return false, nil
+		}
+		return matchStructFields(pattern.Fields, v.Definition.Fields, v.Fields, env)
+	case *ClassInstance:
+		if v.Definition == nil || v.Definition.Name != pattern.Name.Name {
+			return false, nil
+		}
+		return matchStructFields(pattern.Fields, v.Definition.Fields, v.Fields, env)
+	case *EnumInstance:
+		if v.Case != pattern.Name.Name {
+			return false, nil
+		}
+		return matchEnumFields(pattern.Fields, v, env)
+	default:
+		return false, nil
+	}
+}
+
+func matchStructFields(patterns []ast.Pattern, names []string, fields map[string]Value, env *Environment) (bool, error) {
+	if len(patterns) != len(names) {
+		return false, nil
+	}
+	for i, pat := range patterns {
+		name := names[i]
+		val, ok := fields[name]
+		if !ok {
+			return false, nil
+		}
+		matched, err := matchPattern(pat, val, env)
+		if err != nil {
+			return false, err
+		}
+		if !matched {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func matchEnumFields(patterns []ast.Pattern, instance *EnumInstance, env *Environment) (bool, error) {
+	if len(patterns) != len(instance.Order) {
+		return false, nil
+	}
+	for i, pat := range patterns {
+		name := instance.Order[i]
+		val := instance.Fields[name]
+		matched, err := matchPattern(pat, val, env)
+		if err != nil {
+			return false, err
+		}
+		if !matched {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func getProperty(object Value, property string) (Value, bool, error) {
+	switch obj := object.(type) {
+	case *Object:
+		val, ok := obj.Properties[property]
+		return val, ok, nil
+	case *Module:
+		val, ok := obj.Exports[property]
+		return val, ok, nil
+	case *Contract:
+		val, ok := obj.Exports[property]
+		return val, ok, nil
+	case *Array:
+		if property == "length" {
+			return NewNumber(float64(len(obj.Elements))), true, nil
+		}
+		return nil, false, fmt.Errorf("unknown array property %s", property)
+	case *String:
+		if property == "length" {
+			return NewNumber(float64(len(obj.Value))), true, nil
+		}
+		return nil, false, fmt.Errorf("unknown string property %s", property)
+	case *StructInstance:
+		if val, ok := obj.Fields[property]; ok {
+			return val, true, nil
+		}
+		if obj.Definition != nil {
+			if method, ok := obj.Definition.Methods[property]; ok {
+				return bindMethod(method, obj), true, nil
+			}
+			if val, ok := obj.Definition.Static[property]; ok {
+				return val, true, nil
+			}
+		}
+		return nil, false, nil
+	case *StructType:
+		if val, ok := obj.Static[property]; ok {
+			return val, true, nil
+		}
+		if method, ok := obj.Methods[property]; ok {
+			return method, true, nil
+		}
+		return nil, false, nil
+	case *ClassInstance:
+		if val, ok := obj.Fields[property]; ok {
+			return val, true, nil
+		}
+		if method, ok := obj.Definition.lookupMethod(property); ok {
+			return bindMethod(method, obj), true, nil
+		}
+		if val, ok := obj.Definition.lookupStatic(property); ok {
+			return val, true, nil
+		}
+		return nil, false, nil
+	case *ClassType:
+		if val, ok := obj.lookupStatic(property); ok {
+			return val, true, nil
+		}
+		if method, ok := obj.lookupMethod(property); ok {
+			return method, true, nil
+		}
+		return nil, false, nil
+	case *EnumType:
+		val, ok := obj.Constructors[property]
+		return val, ok, nil
+	case *EnumInstance:
+		if property == "case" {
+			return NewString(obj.Case), true, nil
+		}
+		val, ok := obj.Fields[property]
+		return val, ok, nil
+	default:
+		return nil, false, fmt.Errorf("cannot access property %s on %s", property, object.Type())
+	}
+}
+
+func bindMethod(fn *Function, self Value) Value {
+	if fn == nil {
+		return NullValue
+	}
+	if fn.Builtin != nil {
+		return NewBuiltin(fn.Name, func(args []Value) (Value, error) {
+			allArgs := append([]Value{self}, args...)
+			return fn.Builtin(allArgs)
+		})
+	}
+	boundEnv := NewEnclosedEnvironment(fn.Env)
+	boundEnv.Set("self", self)
+	return &Function{Declaration: fn.Declaration, Env: boundEnv, Name: fn.Name}
+}
+
+func cloneStore(store map[string]Value) map[string]Value {
+	out := make(map[string]Value, len(store))
+	for k, v := range store {
+		out[k] = v
+	}
+	return out
+}
+
+func evalModuleDeclaration(module *ast.ModuleDeclaration, env *Environment) (Value, error) {
+	if module.Name == nil {
+		return nil, errors.New("module declaration requires a name")
+	}
+	moduleEnv := NewEnclosedEnvironment(env)
+	if module.Body != nil {
+		if _, err := evalBlock(module.Body, moduleEnv); err != nil {
+			switch err.(type) {
+			case *returnSignal:
+				return nil, errors.New("return not allowed in module body")
+			case *breakSignal, *continueSignal:
+				return nil, errors.New("loop control not allowed in module body")
+			default:
+				return nil, err
+			}
+		}
+	}
+	exports := cloneStore(moduleEnv.store)
+	moduleVal := &Module{Name: module.Name.Name, Exports: exports}
+	env.Set(module.Name.Name, moduleVal)
+	return moduleVal, nil
+}
+
+func evalImportDeclaration(imp *ast.ImportDeclaration, env *Environment) (Value, error) {
+	if len(imp.Path) == 0 {
+		return nil, errors.New("import path cannot be empty")
+	}
+	val, err := resolveImportPath(imp.Path, env)
+	if err != nil {
+		return nil, err
+	}
+	name := imp.Path[len(imp.Path)-1].Name
+	if imp.Alias != nil {
+		name = imp.Alias.Name
+	}
+	env.Set(name, val)
+	return val, nil
+}
+
+func resolveImportPath(path []*ast.Identifier, env *Environment) (Value, error) {
+	var current Value
+	var ok bool
+	for i, segment := range path {
+		if i == 0 {
+			current, ok = env.Get(segment.Name)
+			if !ok {
+				return nil, fmt.Errorf("unknown import %s", segment.Name)
+			}
+			continue
+		}
+		val, found, err := getProperty(current, segment.Name)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			return nil, fmt.Errorf("%s has no property %s", current.Type(), segment.Name)
+		}
+		current = val
+	}
+	return current, nil
+}
+
+func evalStructDeclaration(decl *ast.StructDeclaration, env *Environment) (Value, error) {
+	if decl.Name == nil {
+		return nil, errors.New("struct declaration requires a name")
+	}
+	structType := &StructType{
+		Name:    decl.Name.Name,
+		Fields:  make([]string, 0, len(decl.Params)),
+		Methods: make(map[string]*Function),
+		Static:  make(map[string]Value),
+	}
+	for _, param := range decl.Params {
+		if param.Name != nil {
+			structType.Fields = append(structType.Fields, param.Name.Name)
+		}
+	}
+	bodyEnv := NewEnclosedEnvironment(env)
+	if decl.Body != nil {
+		if _, err := evalBlock(decl.Body, bodyEnv); err != nil {
+			switch err.(type) {
+			case *returnSignal:
+				return nil, errors.New("return not allowed in struct body")
+			case *breakSignal, *continueSignal:
+				return nil, errors.New("loop control not allowed in struct body")
+			default:
+				return nil, err
+			}
+		}
+	}
+	for name, val := range bodyEnv.store {
+		switch v := val.(type) {
+		case *Function:
+			structType.Methods[name] = v
+		default:
+			structType.Static[name] = v
+		}
+	}
+	env.Set(structType.Name, structType)
+	return structType, nil
+}
+
+func evalClassDeclaration(decl *ast.ClassDeclaration, env *Environment) (Value, error) {
+	if decl.Name == nil {
+		return nil, errors.New("class declaration requires a name")
+	}
+	classType := &ClassType{
+		Name:    decl.Name.Name,
+		Fields:  make([]string, 0, len(decl.Params)),
+		Methods: make(map[string]*Function),
+		Static:  make(map[string]Value),
+	}
+	for _, param := range decl.Params {
+		if param.Name != nil {
+			classType.Fields = append(classType.Fields, param.Name.Name)
+		}
+	}
+	if decl.SuperClass != nil {
+		superVal, ok := env.Get(decl.SuperClass.Name)
+		if !ok {
+			return nil, fmt.Errorf("unknown superclass %s", decl.SuperClass.Name)
+		}
+		superType, ok := superVal.(*ClassType)
+		if !ok {
+			return nil, fmt.Errorf("%s is not a class", decl.SuperClass.Name)
+		}
+		classType.Super = superType
+		for name, method := range superType.Methods {
+			classType.Methods[name] = method
+		}
+		for name, val := range superType.Static {
+			classType.Static[name] = val
+		}
+	}
+
+	bodyEnv := NewEnclosedEnvironment(env)
+	if decl.Body != nil {
+		if _, err := evalBlock(decl.Body, bodyEnv); err != nil {
+			switch err.(type) {
+			case *returnSignal:
+				return nil, errors.New("return not allowed in class body")
+			case *breakSignal, *continueSignal:
+				return nil, errors.New("loop control not allowed in class body")
+			default:
+				return nil, err
+			}
+		}
+	}
+	for name, val := range bodyEnv.store {
+		switch v := val.(type) {
+		case *Function:
+			classType.Methods[name] = v
+		default:
+			classType.Static[name] = v
+		}
+	}
+	env.Set(classType.Name, classType)
+	return classType, nil
+}
+
+func evalEnumDeclaration(decl *ast.EnumDeclaration, env *Environment) (Value, error) {
+	if decl.Name == nil {
+		return nil, errors.New("enum declaration requires a name")
+	}
+	enumType := &EnumType{
+		Name:         decl.Name.Name,
+		Cases:        make(map[string][]string),
+		Constructors: make(map[string]Value),
+	}
+	for _, c := range decl.Cases {
+		if c.Name == nil {
+			continue
+		}
+		params := make([]string, 0, len(c.Params))
+		for _, p := range c.Params {
+			if p.Name != nil {
+				params = append(params, p.Name.Name)
+			}
+		}
+		enumType.Cases[c.Name.Name] = params
+		enumType.Constructors[c.Name.Name] = newEnumConstructor(enumType, c.Name.Name, params)
+	}
+	env.Set(enumType.Name, enumType)
+	return enumType, nil
+}
+
+func evalContractDeclaration(decl *ast.ContractDeclaration, env *Environment) (Value, error) {
+	if decl.Name == nil {
+		return nil, errors.New("contract declaration requires a name")
+	}
+	bodyEnv := NewEnclosedEnvironment(env)
+	if decl.Body != nil {
+		if _, err := evalBlock(decl.Body, bodyEnv); err != nil {
+			switch err.(type) {
+			case *returnSignal:
+				return nil, errors.New("return not allowed in contract body")
+			case *breakSignal, *continueSignal:
+				return nil, errors.New("loop control not allowed in contract body")
+			default:
+				return nil, err
+			}
+		}
+	}
+	contract := &Contract{Name: decl.Name.Name, Exports: cloneStore(bodyEnv.store)}
+	env.Set(contract.Name, contract)
+	return contract, nil
+}
+
+func instantiateStruct(structType *StructType, args []Value) (Value, error) {
+	if len(args) != len(structType.Fields) {
+		return nil, fmt.Errorf("expected %d arguments to %s, got %d", len(structType.Fields), structType.Name, len(args))
+	}
+	fields := make(map[string]Value, len(structType.Fields))
+	for i, name := range structType.Fields {
+		fields[name] = args[i]
+	}
+	instance := &StructInstance{Definition: structType, Fields: fields}
+	if init, ok := structType.Methods["init"]; ok {
+		if err := callInitializer(init, instance); err != nil {
+			return nil, err
+		}
+	}
+	return instance, nil
+}
+
+func instantiateClass(classType *ClassType, args []Value) (Value, error) {
+	if len(args) != len(classType.Fields) {
+		return nil, fmt.Errorf("expected %d arguments to %s, got %d", len(classType.Fields), classType.Name, len(args))
+	}
+	fields := make(map[string]Value, len(classType.Fields))
+	for i, name := range classType.Fields {
+		fields[name] = args[i]
+	}
+	instance := &ClassInstance{Definition: classType, Fields: fields}
+	if init, ok := classType.lookupMethod("init"); ok {
+		if err := callInitializer(init, instance); err != nil {
+			return nil, err
+		}
+	}
+	return instance, nil
+}
+
+func callInitializer(fn *Function, self Value) error {
+	bound := bindMethod(fn, self)
+	_, err := applyFunction(bound, []Value{})
+	return err
+}
+
+func newEnumConstructor(enum *EnumType, caseName string, params []string) Value {
+	return NewBuiltin(caseName, func(args []Value) (Value, error) {
+		if len(args) != len(params) {
+			return nil, fmt.Errorf("expected %d arguments to %s.%s, got %d", len(params), enum.Name, caseName, len(args))
+		}
+		fields := make(map[string]Value, len(params))
+		order := make([]string, len(params))
+		for i, name := range params {
+			fields[name] = args[i]
+			order[i] = name
+		}
+		return &EnumInstance{Enum: enum, Case: caseName, Fields: fields, Order: order}, nil
+	})
+}
+
+func enforceContract(block *ast.ContractBlock, env *Environment, result Value, fnName string) error {
+	if block == nil {
+		return nil
+	}
+	for _, clause := range block.Clauses {
+		clauseEnv := NewEnclosedEnvironment(env)
+		clauseEnv.Set("result", result)
+		guardSatisfied := true
+		if clause.Guard != nil {
+			guard, err := evalExpression(clause.Guard, clauseEnv)
+			if err != nil {
+				return err
+			}
+			guardSatisfied = isTruthy(guard)
+		}
+		if !guardSatisfied {
+			continue
+		}
+		condition, err := evalExpression(clause.Condition, clauseEnv)
+		if err != nil {
+			return err
+		}
+		if !isTruthy(condition) {
+			if fnName != "" {
+				return fmt.Errorf("contract violation in %s", fnName)
+			}
+			return errors.New("contract violation")
+		}
+	}
+	return nil
+}
+
+func applyFunction(fn Value, args []Value) (Value, error) {
+	switch callable := fn.(type) {
+	case *Function:
+		if callable.Builtin != nil {
+			return callable.Builtin(args)
+		}
+		if callable.Declaration == nil {
+			return nil, errors.New("function has no body")
+		}
+		if len(args) != len(callable.Declaration.Params) {
+			return nil, fmt.Errorf("expected %d arguments, got %d", len(callable.Declaration.Params), len(args))
+		}
+
+		callEnv := NewEnclosedEnvironment(callable.Env)
+		for i, param := range callable.Declaration.Params {
+			callEnv.Set(param.Name.Name, args[i])
+		}
+
+		var result Value = NullValue
+		var err error
+		if callable.Declaration.IsExprBody {
+			if callable.Declaration.BodyExpr != nil {
+				result, err = evalExpression(callable.Declaration.BodyExpr, callEnv)
+			}
+		} else if callable.Declaration.Body != nil {
+			result, err = evalBlock(callable.Declaration.Body, callEnv)
+			if err != nil {
+				switch sig := err.(type) {
+				case *returnSignal:
+					result = sig.value
+					err = nil
+				case *breakSignal:
+					err = errors.New("break outside of loop")
+				case *continueSignal:
+					err = errors.New("continue outside of loop")
+				}
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		if callable.Declaration.Contract != nil {
+			if err := enforceContract(callable.Declaration.Contract, callEnv, result, callable.Name); err != nil {
+				return nil, err
+			}
+		}
+		return result, nil
+	case *StructType:
+		return instantiateStruct(callable, args)
+	case *ClassType:
+		return instantiateClass(callable, args)
+	default:
+		return nil, fmt.Errorf("%s is not callable", fn.Type())
+	}
+}
+
+func builtinPrint(args []Value) (Value, error) {
+	parts := make([]string, len(args))
+	for i, arg := range args {
+		parts[i] = arg.Inspect()
+	}
+	fmt.Println(strings.Join(parts, " "))
+	return NullValue, nil
+}

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -1,0 +1,143 @@
+package token
+
+import "fmt"
+
+// Type represents the type of lexical token.
+type Type string
+
+// Token represents a lexical token with positional metadata.
+type Token struct {
+	Type    Type
+	Literal string
+	Pos     Position
+	End     Position
+}
+
+// Position describes a location within a source file.
+type Position struct {
+	Offset int
+	Line   int
+	Column int
+}
+
+func (p Position) String() string {
+	return fmt.Sprintf("%d:%d", p.Line, p.Column)
+}
+
+const (
+	// Special tokens
+	ILLEGAL Type = "ILLEGAL"
+	EOF     Type = "EOF"
+
+	// Identifiers + literals
+	IDENT  Type = "IDENT"
+	NUMBER Type = "NUMBER"
+	STRING Type = "STRING"
+	TRUE   Type = "TRUE"
+	FALSE  Type = "FALSE"
+	NULL   Type = "NULL"
+
+	// Operators
+	ASSIGN         Type = "="
+	PLUS           Type = "+"
+	MINUS          Type = "-"
+	ASTERISK       Type = "*"
+	SLASH          Type = "/"
+	PERCENT        Type = "%"
+	PLUS_ASSIGN    Type = "+="
+	MINUS_ASSIGN   Type = "-="
+	STAR_ASSIGN    Type = "*="
+	SLASH_ASSIGN   Type = "/="
+	PERCENT_ASSIGN Type = "%="
+	BANG           Type = "!"
+	QUESTION       Type = "?"
+	COLON          Type = ":"
+	ELVIS          Type = "?:"
+	SAFE_DOT       Type = "?."
+	NON_NULL       Type = "!!"
+	EQ             Type = "=="
+	NOT_EQ         Type = "!="
+	LT             Type = "<"
+	LTE            Type = "<="
+	GT             Type = ">"
+	GTE            Type = ">="
+	OR             Type = "||"
+	AND            Type = "&&"
+	ARROW          Type = "=>"
+	IS             Type = "is"
+	NOT_IS         Type = "!is"
+
+	// Delimiters
+	COMMA     Type = ","
+	DOT       Type = "."
+	SEMICOLON Type = ";"
+	LPAREN    Type = "("
+	RPAREN    Type = ")"
+	LBRACE    Type = "{"
+	RBRACE    Type = "}"
+	LBRACKET  Type = "["
+	RBRACKET  Type = "]"
+)
+
+const (
+	// Keywords
+	LET      Type = "let"
+	VAR      Type = "var"
+	FN       Type = "fn"
+	ASYNC    Type = "async"
+	CONTRACT Type = "contract"
+	RETURNS  Type = "returns"
+	CLASS    Type = "class"
+	STRUCT   Type = "struct"
+	ENUM     Type = "enum"
+	MATCH    Type = "match"
+	MODULE   Type = "module"
+	IMPORT   Type = "import"
+	AS       Type = "as"
+	PACKAGE  Type = "package"
+	IF       Type = "if"
+	ELSE     Type = "else"
+	WHILE    Type = "while"
+	FOR      Type = "for"
+	RETURN   Type = "return"
+	BREAK    Type = "break"
+	CONTINUE Type = "continue"
+	AWAIT    Type = "await"
+)
+
+var keywords = map[string]Type{
+	"let":      LET,
+	"var":      VAR,
+	"fn":       FN,
+	"async":    ASYNC,
+	"contract": CONTRACT,
+	"returns":  RETURNS,
+	"class":    CLASS,
+	"struct":   STRUCT,
+	"enum":     ENUM,
+	"match":    MATCH,
+	"module":   MODULE,
+	"import":   IMPORT,
+	"as":       AS,
+	"package":  PACKAGE,
+	"if":       IF,
+	"else":     ELSE,
+	"while":    WHILE,
+	"for":      FOR,
+	"return":   RETURN,
+	"break":    BREAK,
+	"continue": CONTINUE,
+	"true":     TRUE,
+	"false":    FALSE,
+	"null":     NULL,
+	"is":       IS,
+	"await":    AWAIT,
+}
+
+// LookupIdent identifies reserved keywords.
+func LookupIdent(ident string) Type {
+	if tok, ok := keywords[ident]; ok {
+		return tok
+	}
+	return IDENT
+}


### PR DESCRIPTION
## Summary
- add package declarations, string-based import aliases, and augmented assignment operators across the lexer, parser, AST, and runtime
- record package metadata at runtime and evaluate new assignment operators while keeping backward-compatible identifier imports
- document the features and provide a new packages example highlighting Go-style imports and compound assignment

## Testing
- go build ./...
- go run ./cmd/selene examples/packages.selene
- go run ./cmd/selene examples/modules.selene

------
https://chatgpt.com/codex/tasks/task_e_68df75d68af8832eb5df58e1ac665c75