### PR TITLE
Add secure dependency tooling and update grammar

### DIFF
--- a/ModernLang.g4
+++ b/ModernLang.g4
@@ -2,30 +2,97 @@ grammar ModernLang;
 
 // ---------------- LEXICAL ----------------
 
-IDENTIFIER  : [a-zA-Z_] [a-zA-Z0-9_]* ;
-NUMBER      : [0-9]+ ;
-STRING      : '"' (~["\\] | '\\' .)* '"' ;
-BOOLEAN     : 'true' | 'false' ;
-NULL        : 'null' ;
+PACKAGE    : 'package';
+MODULE     : 'module';
+IMPORT     : 'import';
+AS         : 'as';
+LET        : 'let';
+VAR        : 'var';
+FN         : 'fn';
+ASYNC      : 'async';
+CONTRACT   : 'contract';
+RETURNS    : 'returns';
+CLASS      : 'class';
+STRUCT     : 'struct';
+ENUM       : 'enum';
+INTERFACE  : 'interface';
+EXT        : 'ext';
+MATCH      : 'match';
+IF         : 'if';
+ELSE       : 'else';
+WHILE      : 'while';
+FOR        : 'for';
+USING      : 'using';
+TRY        : 'try';
+CATCH      : 'catch';
+FINALLY    : 'finally';
+THROW      : 'throw';
+RETURN     : 'return';
+BREAK      : 'break';
+CONTINUE   : 'continue';
+CONDITION  : 'condition';
+WHEN       : 'when';
+AWAIT      : 'await';
+TRUE       : 'true';
+FALSE      : 'false';
+NULL       : 'null';
+IS         : 'is';
+NOTIS      : '!is';
 
-WS          : [ \t\r\n]+ -> skip ;
-COMMENT     : '//' ~[\r\n]* -> skip ;
-BLOCK_COMMENT : '/*' .*? '*/' -> skip ;
+AMPERSAND  : '&';
+
+PLUS_ASSIGN    : '+=';
+MINUS_ASSIGN   : '-=';
+STAR_ASSIGN    : '*=';
+SLASH_ASSIGN   : '/=';
+PERCENT_ASSIGN : '%=';
+ELVIS          : '?:';
+SAFE_DOT       : '?.';
+NON_NULL       : '!!';
+
+IDENTIFIER : [a-zA-Z_] [a-zA-Z0-9_]* ;
+NUMBER     : [0-9]+ ('.' [0-9]+)? ;
+STRING     : '"' (~['"'\\] | '\\' .)* '"';
+FORMATSTRING
+           : 'f"' (~['"'\\] | '\\' .)* '"'
+           | 'f"""' .*? '"""'
+           ;
+RAWSTRING  : 'r"' (~['"'\\])* '"'
+           | 'r"""' .*? '"""'
+           | '`' .*? '`'
+           ;
+BOOLEAN    : TRUE | FALSE;
+
+WS           : [ \t\r\n]+ -> skip;
+COMMENT      : '//' ~[\r\n]* -> skip;
+BLOCK_COMMENT: '/*' .*? '*/' -> skip;
 
 // ---------------- PROGRAM ----------------
 
 program
-    : (moduleDecl | statement)* EOF
+    : packageDecl? (moduleDecl | statement)* EOF
+    ;
+
+packageDecl
+    : PACKAGE IDENTIFIER ';'?
     ;
 
 // ---------------- MODULES ----------------
 
 moduleDecl
-    : 'module' IDENTIFIER block
+    : MODULE IDENTIFIER block?
     ;
 
 importDecl
-    : 'import' qualifiedName ('as' IDENTIFIER)? ';'
+    : IMPORT (
+          IDENTIFIER STRING (AS IDENTIFIER)?
+        | importPath (AS IDENTIFIER)?
+      ) ';'
+    ;
+
+importPath
+    : IDENTIFIER ('.' IDENTIFIER)*
+    | STRING
     ;
 
 qualifiedName
@@ -37,12 +104,24 @@ qualifiedName
 statement
     : variableDecl
     | functionDecl
+    | extensionDecl
     | classDecl
     | structDecl
     | enumDecl
+    | interfaceDecl
     | contractDecl
     | importDecl
     | matchStmt
+    | ifStmt
+    | whileStmt
+    | forStmt
+    | usingStmt
+    | tryStmt
+    | throwStmt
+    | returnStmt
+    | breakStmt
+    | continueStmt
+    | conditionStmt
     | block
     | expression ';'
     ;
@@ -54,13 +133,17 @@ block
 // ---------------- VARIABLES ----------------
 
 variableDecl
-    : ('let' | 'var') IDENTIFIER (':' type_)? '=' expression ';'
+    : (LET | VAR) IDENTIFIER (':' type_)? '=' expression ';'
     ;
 
 // ---------------- FUNCTIONS ----------------
 
 functionDecl
-    : 'fn' IDENTIFIER typeParams? '(' paramList? ')' (':' type_)? ('async')? contractBlock? (block | '=' expression ';')
+    : FN IDENTIFIER typeParams? '(' paramList? ')' (':' type_)? (ASYNC)? contractBlock? (block | ('=' | '=>') expression ';'?)
+    ;
+
+extensionDecl
+    : EXT FN typeAnnotation '.' IDENTIFIER typeParams? '(' paramList? ')' (':' type_)? (ASYNC)? contractBlock? (block | ('=' | '=>') expression ';'?)
     ;
 
 paramList
@@ -78,39 +161,128 @@ typeParams
 // ---------------- CONTRACTS ----------------
 
 contractBlock
-    : 'contract' '{' contractClause* '}'
+    : CONTRACT '{' contractClause* '}'
     ;
 
 contractClause
-    : 'returns' '(' expression? ')' '=>' expression ';'
+    : RETURNS '(' expression? ')' '=>' expression ';'
+    ;
+
+// ---------------- TYPES ----------------
+
+type_
+    : typeAnnotation
+    ;
+
+typeAnnotation
+    : IDENTIFIER typeArgs? '?'?
+    ;
+
+typeArgs
+    : '<' typeAnnotation (',' typeAnnotation)* '>'
     ;
 
 // ---------------- CLASSES ----------------
 
 classDecl
-    : 'class' IDENTIFIER '(' paramList? ')' (':' IDENTIFIER)? block?
+    : CLASS IDENTIFIER '(' paramList? ')' (':' IDENTIFIER)? block?
     ;
-
-// ---------------- STRUCTS ----------------
 
 structDecl
-    : 'struct' IDENTIFIER '(' paramList? ')' block?
+    : STRUCT IDENTIFIER '(' paramList? ')' block?
     ;
 
-// ---------------- ENUMS ----------------
-
 enumDecl
-    : 'enum' IDENTIFIER typeParams? '{' enumCase* '}'
+    : ENUM IDENTIFIER typeParams? '{' enumCase* '}'
     ;
 
 enumCase
     : IDENTIFIER ('(' paramList? ')')? ';'
     ;
 
+interfaceDecl
+    : INTERFACE IDENTIFIER '{' interfaceMember* '}'
+    ;
+
+interfaceMember
+    : FN IDENTIFIER '(' paramList? ')' (':' type_)? ';'
+    ;
+
+contractDecl
+    : CONTRACT IDENTIFIER block
+    ;
+
+// ---------------- CONTROL FLOW ----------------
+
+ifStmt
+    : IF expression block (ELSE statement)?
+    ;
+
+whileStmt
+    : WHILE expression block
+    ;
+
+forStmt
+    : FOR '(' forInit? ';' expression? ';' expression? ')' block
+    ;
+
+forInit
+    : variableBinding
+    | expression
+    ;
+
+variableBinding
+    : (LET | VAR) IDENTIFIER (':' type_)? '=' expression
+    ;
+
+usingStmt
+    : USING (IDENTIFIER '=')? expression block
+    ;
+
+tryStmt
+    : TRY block catchClause? finallyClause?
+    ;
+
+catchClause
+    : CATCH ('(' IDENTIFIER? ')')? block
+    ;
+
+finallyClause
+    : FINALLY block
+    ;
+
+throwStmt
+    : THROW expression ';'?
+    ;
+
+returnStmt
+    : RETURN expression? ';'?
+    ;
+
+breakStmt
+    : BREAK ';'?
+    ;
+
+continueStmt
+    : CONTINUE ';'?
+    ;
+
+conditionStmt
+    : CONDITION '{' conditionClause* conditionElse? '}'
+    ;
+
+conditionClause
+    : WHEN expression '=>' block
+    ;
+
+conditionElse
+    : ELSE '=>' block
+    ;
+
 // ---------------- MATCH ----------------
 
 matchStmt
-    : 'match' expression '{' matchCase+ '}'
+    : MATCH expression '{' matchCase+ '}'
     ;
 
 matchCase
@@ -127,6 +299,8 @@ pattern
 literalPattern
     : NUMBER
     | STRING
+    | FORMATSTRING
+    | RAWSTRING
     | BOOLEAN
     | NULL
     ;
@@ -150,11 +324,11 @@ expression
     ;
 
 assignment
-    : conditional ('=' expression)?
+    : conditional (( '=' | PLUS_ASSIGN | MINUS_ASSIGN | STAR_ASSIGN | SLASH_ASSIGN | PERCENT_ASSIGN ) expression)?
     ;
 
 conditional
-    : logicalOr ('?:' expression)?
+    : logicalOr (ELVIS expression)?
     ;
 
 logicalOr
@@ -170,7 +344,7 @@ equality
     ;
 
 comparison
-    : additive (( '<' | '<=' | '>' | '>=' | 'is' | '!is' ) additive)*
+    : additive (( '<' | '<=' | '>' | '>=' | IS | NOTIS ) additive)*
     ;
 
 additive
@@ -182,16 +356,18 @@ multiplicative
     ;
 
 unary
-    : ('!' | '-') unary
+    : ('!' | '-' | AMPERSAND | '*') unary
     | postfix
     ;
 
+AMPERSAND : '&';
+
 postfix
-    : primary ( 
+    : primary (
         '.' IDENTIFIER
       | '[' expression ']'
-      | '?.' IDENTIFIER
-      | '!!'
+      | SAFE_DOT IDENTIFIER
+      | NON_NULL
       | '(' argumentList? ')'
     )*
     ;
@@ -203,6 +379,8 @@ argumentList
 primary
     : NUMBER
     | STRING
+    | FORMATSTRING
+    | RAWSTRING
     | BOOLEAN
     | NULL
     | IDENTIFIER
@@ -225,15 +403,5 @@ pair
     ;
 
 awaitExpr
-    : 'await' expression
-    ;
-
-// ---------------- TYPES ----------------
-
-type_
-    : IDENTIFIER typeArgs? '?'?
-    ;
-
-typeArgs
-    : '<' type_ (',' type_)* '>'
+    : AWAIT expression
     ;

--- a/README.md
+++ b/README.md
@@ -1,0 +1,203 @@
+# Selene Language Toolkit
+
+Selene is an experimental programming language frontend implemented in Go. The toolchain now includes a lexer, Pratt-style parser, rich abstract syntax tree (AST) types, and a lightweight tree-walking interpreter. Use it to experiment with language ideas, embed Selene as a scripting language, or extend the runtime with new features.
+
+## Features
+
+- **Tokenization** – The lexer understands Selene keywords, operators, and literals while skipping both line (`// ...`) and block (`/* ... */`) comments with precise source positions.
+- **AST definitions** – The `internal/ast` package models programs, declarations, statements, expressions, patterns, and contracts with positional metadata for diagnostics and tooling.
+- **Pratt parser** – The parser supports modules, variable and function declarations, class/struct/enum definitions, contracts, match statements with pattern destructuring, and rich expression precedence (assignment, Elvis, logical, comparison, arithmetic, calls, indexing, and safe navigation).
+- **Runtime interpreter** – The `internal/runtime` package evaluates Selene programs with lexical scoping, package declarations, modules and imports (including Go-style string imports and aliases), immutable/mutable bindings, first-class functions, user-defined structs/classes/enums, arrays, objects, and rich control flow (`if`/`for`/`while`, `return`, `break`, `continue`). The runtime now supports pointer semantics (`&` and `*`), extension functions declared with `ext fn`, structural interfaces with `is`/`!is`, expressive string literals (interpolation with `${}`, format specifiers via `f"..."`, raw/triple-quoted strings), resource-safe `using` blocks, structured `try`/`catch`/`finally` plus `throw`, lightweight concurrency primitives (`spawn`, `channel`, `await`), rule-based `condition { when ... }` dispatch, and a growing standard library (`print`, `format`, `spawn`, `channel`). Function contracts are enforced at call time.
+- **Project metadata** – The repository includes a `selene.toml` manifest and companion `selene.lock` file that describe the project module path, entry point, documentation roots, example directories, and vendored dependencies with reproducible SHA-256 checksums.
+- **CLI utility** – The `cmd/selene` binary can execute Selene scripts, dump the raw token stream, scaffold new workspaces, and manage vendored dependencies with secure checksum verification.
+
+## Installation
+
+Selene is distributed as a standard Go module. With Go 1.21 or newer installed, fetch the dependencies and build the CLI:
+
+```bash
+go mod tidy
+go build ./...
+```
+
+To install the `selene` CLI in your `$GOBIN`, run:
+
+```bash
+go install ./cmd/selene
+```
+
+## Writing your first Selene script
+
+Create `examples/hello.selene` with a few declarations and expressions:
+
+```selene
+// examples/hello.selene
+let greeting: String = "Hello";
+
+fn greet(name: String): String => greeting + ", " + name;
+
+fn main() {
+    print(greet("Selene"));
+}
+
+main();
+```
+
+This script demonstrates immutable `let` bindings, optional type annotations, expression-bodied functions (`=>`), string concatenation, first-class functions, and calling the built-in `print` helper. The final `main();` call drives execution just like a typical scripting entry point.
+
+## Using the CLI
+
+Run a script to execute it:
+
+```bash
+selene run examples/hello.selene
+```
+
+Expected output:
+
+```
+Hello, Selene
+```
+
+Inspect the token stream instead of running the program:
+
+```bash
+selene tokens examples/hello.selene
+```
+
+You will see one token per line, including keywords, identifiers, punctuation, and literals.
+
+Initialize a new project with a manifest, documentation, and starter source file:
+
+```bash
+selene init github.com/you/awesome-selene --name "awesome-selene"
+```
+
+Manage dependencies by vendoring local or remote sources with cryptographic checksums:
+
+```bash
+# Vendor a dependency from a local checkout (or a freshly cloned repository)
+selene deps add --path ../richmath --source https://github.com/selene-lang/richmath github.com/selene-lang/richmath v1.0.0
+
+# Inspect the recorded requirements
+selene deps list
+
+# Recalculate hashes to ensure the vendor tree matches selene.lock
+selene deps verify
+```
+
+The dependency commands update both `selene.toml` and `selene.lock`, ensuring repeatable builds and tamper-proof vendored content.
+
+## Example gallery
+
+Explore the scripts in the `examples/` directory to get a feel for different Selene features:
+
+- `examples/hello.selene` – introductory greetings, expression-bodied functions, and simple printing.
+- `examples/math.selene` – arithmetic helpers, composing functions, and string interpolation via `+` concatenation.
+- `examples/collections.selene` – arrays, objects, optional property access, and indexing into both arrays and strings.
+- `examples/options.selene` – optional chaining, Elvis defaults, and non-null assertions in practice.
+- `examples/patterns.selene` – destructuring objects with `match` statements and pattern bindings.
+- `examples/recursion.selene` – recursive functions that use `match` clauses for control flow.
+- `examples/control.selene` – `if`/`else` branches, `for`/`while` loops, and the `return`/`break`/`continue` statements.
+- `examples/types.selene` – struct methods, simple classes, enums, and pattern matching on enum cases.
+- `examples/modules.selene` – modules, identifier-based imports, and reusing exported helpers.
+- `examples/packages.selene` – package headers, Go-style string imports, and augmented assignment in action.
+- `examples/contracts.selene` – standalone contract declarations and inline postconditions that validate function results.
+- `examples/strings.selene` – interpolation, formatting directives, raw strings, and triple-quoted literals.
+- `examples/extensions.selene` – extension methods on built-in types and reusable fluent helpers.
+- `examples/pointers.selene` – address-of/dereference, pointer aliasing, and swapping values by reference.
+- `examples/interfaces.selene` – structural interface conformance with classes, structs, and extension functions.
+- `examples/concurrency.selene` – spawning tasks, communicating over channels, and awaiting asynchronous work.
+- `examples/errors.selene` – `using` statements, `try`/`catch`/`finally`, and explicit `throw` expressions.
+- `examples/conditions.selene` – `condition` dispatch blocks for rule-driven, OOP-style control flow.
+- `examples/dependency.selene` – importing a vendored module from `github.com/selene-lang/richmath` using string-based package paths.
+
+Run any script with `selene path/to/script.selene` to see the output directly in your terminal.
+
+## Documentation site
+
+The repository ships with a `docs/` folder that is ready to publish with [GitHub Pages](https://docs.github.com/en/pages). To
+serve the reference documentation:
+
+1. Open the repository settings on GitHub.
+2. Under **Pages**, choose the `main` branch and `/docs` folder as the publishing source.
+3. Save the settings—within a minute GitHub will build and host the static site.
+
+The generated site contains:
+
+- A project overview and quick-start guide.
+- Detailed walkthroughs of Selene syntax and runtime capabilities.
+- A comprehensive [language reference](reference.md) cataloging every construct supported by the lexer and parser.
+- Embedding examples showing how to execute Selene from your own Go programs.
+
+## Embedding Selene as a scripting language
+
+Use the lexer, parser, and runtime packages to execute Selene inside your Go application:
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+
+    "selenelang/internal/lexer"
+    "selenelang/internal/parser"
+    "selenelang/internal/runtime"
+)
+
+func main() {
+    script, err := os.ReadFile("examples/hello.selene")
+    if err != nil {
+        panic(err)
+    }
+
+    l := lexer.New(string(script))
+    p := parser.New(l)
+    program := p.ParseProgram()
+    if errs := p.Errors(); len(errs) > 0 {
+        panic(errs)
+    }
+
+    rt := runtime.New()
+    if _, err := rt.Run(program); err != nil {
+        panic(err)
+    }
+
+    fmt.Println("script executed successfully")
+}
+```
+
+From here you can:
+
+- Extend the runtime with additional built-in functions or host integrations.
+- Compile Selene into another language or bytecode target.
+- Write linters, formatters, or static analyzers that inspect the rich node metadata.
+
+Because every node exposes both `Pos()` and `End()` locations, it is straightforward to produce precise diagnostics or IDE features.
+
+## Project layout
+
+```
+cmd/selene/         CLI entry point
+internal/token/     Token definitions and keyword lookup
+internal/lexer/     Scanner producing tokens with positions
+internal/parser/    Pratt parser producing AST nodes
+internal/ast/       AST node structures used by the parser
+internal/runtime/   Tree-walking interpreter and runtime values
+examples/           Sample Selene sources for experimentation
+vendor/             Vendored Selene packages with checksums
+selene.toml        Project manifest and dependency metadata
+selene.lock        Locked dependency checksums for verification
+```
+
+## Next steps
+
+Selene currently ships with a minimal interpreter focused on core language features. Future work could explore:
+
+- A richer standard library, asynchronous execution primitives, or packaging support for larger projects.
+- A bytecode compiler and virtual machine.
+- Source-to-source transpilers or code generators.
+- Language services like formatting, symbol indexing, or IDE support.
+
+Contributions and experiments are welcome—have fun exploring new language ideas with Selene!

--- a/cmd/selene/main.go
+++ b/cmd/selene/main.go
@@ -1,0 +1,423 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"selenelang/internal/lexer"
+	"selenelang/internal/parser"
+	"selenelang/internal/project"
+	"selenelang/internal/runtime"
+	"selenelang/internal/token"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "run":
+		if err := runCommand(os.Args[2:]); err != nil {
+			exitWithError(err)
+		}
+	case "tokens":
+		if err := tokensCommand(os.Args[2:]); err != nil {
+			exitWithError(err)
+		}
+	case "init":
+		if err := initCommand(os.Args[2:]); err != nil {
+			exitWithError(err)
+		}
+	case "deps":
+		if err := depsCommand(os.Args[2:]); err != nil {
+			exitWithError(err)
+		}
+	default:
+		if err := runCommand(os.Args[1:]); err != nil {
+			exitWithError(err)
+		}
+	}
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "usage: selene <command> [options]")
+	fmt.Fprintln(os.Stderr, "commands:")
+	fmt.Fprintln(os.Stderr, "  run [--tokens] <file>   execute a Selene source file")
+	fmt.Fprintln(os.Stderr, "  tokens <file>           dump the token stream for a file")
+	fmt.Fprintln(os.Stderr, "  init <module> [--name]  create a new Selene project")
+	fmt.Fprintln(os.Stderr, "  deps <subcommand>       manage project dependencies (add, list, verify)")
+}
+
+func exitWithError(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}
+
+func runCommand(args []string) error {
+	fs := flag.NewFlagSet("run", flag.ContinueOnError)
+	tokensFlag := fs.Bool("tokens", false, "print the token stream")
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() == 0 {
+		return errors.New("run requires a source file")
+	}
+	filename := fs.Arg(0)
+	if *tokensFlag {
+		return dumpTokens(filename)
+	}
+	rt := runtime.New()
+	if err := loadDependencies(rt, filename); err != nil {
+		return err
+	}
+	return executeFile(rt, filename)
+}
+
+func tokensCommand(args []string) error {
+	fs := flag.NewFlagSet("tokens", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() == 0 {
+		return errors.New("tokens requires a source file")
+	}
+	return dumpTokens(fs.Arg(0))
+}
+
+func initCommand(args []string) error {
+	fs := flag.NewFlagSet("init", flag.ContinueOnError)
+	nameFlag := fs.String("name", "", "project name to record in the manifest")
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() == 0 {
+		return errors.New("init requires a module path (e.g. github.com/user/project)")
+	}
+	modulePath := fs.Arg(0)
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(filepath.Join(cwd, project.ManifestName)); err == nil {
+		return fmt.Errorf("selene.toml already exists in %s", cwd)
+	}
+	projectName := *nameFlag
+	if projectName == "" {
+		parts := strings.Split(modulePath, "/")
+		projectName = parts[len(parts)-1]
+	}
+	manifest := &project.Manifest{}
+	manifest.Project.Name = projectName
+	manifest.Project.Version = "0.1.0"
+	manifest.Project.Module = modulePath
+	manifest.Project.Entry = filepath.ToSlash(filepath.Join("src", "main.selene"))
+	manifest.Docs.Paths = []string{"docs", "README.md"}
+	manifest.Examples.Roots = []string{"examples"}
+	manifest.Dependencies = make(map[string]project.Dependency)
+	if err := project.SaveManifest(cwd, manifest); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(cwd, "src"), 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(cwd, "examples"), 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(cwd, "docs"), 0o755); err != nil {
+		return err
+	}
+	mainSource := "package main;\n\nfn main() {\n    print(\"Hello from " + projectName + "!\");\n}\n\nmain();\n"
+	entryPath := filepath.Join(cwd, "src", "main.selene")
+	if err := os.WriteFile(entryPath, []byte(mainSource), 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "initialized Selene module %s\n", modulePath)
+	return nil
+}
+
+func depsCommand(args []string) error {
+	if len(args) == 0 {
+		return errors.New("deps requires a subcommand: add, list, verify")
+	}
+	switch args[0] {
+	case "add":
+		return depsAdd(args[1:])
+	case "list":
+		return depsList(args[1:])
+	case "verify":
+		return depsVerify(args[1:])
+	default:
+		return fmt.Errorf("unknown deps subcommand %q", args[0])
+	}
+}
+
+func depsAdd(args []string) error {
+	fs := flag.NewFlagSet("deps add", flag.ContinueOnError)
+	srcPath := fs.String("path", "", "path to the dependency sources to vendor")
+	sourceURL := fs.String("source", "", "canonical repository URL for auditing")
+	fs.SetOutput(os.Stderr)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() < 2 {
+		return errors.New("deps add requires a module path and version")
+	}
+	module := fs.Arg(0)
+	version := fs.Arg(1)
+	if *sourceURL == "" {
+		*sourceURL = module
+	}
+	root, err := project.FindRoot(mustGetwd())
+	if err != nil {
+		return fmt.Errorf("cannot locate selene.toml: %w", err)
+	}
+	manifest, err := project.LoadManifest(root)
+	if err != nil {
+		return err
+	}
+	dep, lockEntry, err := project.PrepareDependency(root, module, version, *sourceURL, *srcPath)
+	if err != nil {
+		return err
+	}
+	manifest.Dependencies[module] = dep
+	if err := project.SaveManifest(root, manifest); err != nil {
+		return err
+	}
+	lockfile, err := project.LoadLockfile(root)
+	if err != nil {
+		return err
+	}
+	lockfile.Set(lockEntry)
+	if err := project.SaveLockfile(root, lockfile); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "added %s %s (checksum %s)\n", module, version, lockEntry.Checksum)
+	return nil
+}
+
+func depsList(args []string) error {
+	if len(args) != 0 {
+		return errors.New("deps list does not take additional arguments")
+	}
+	root, err := project.FindRoot(mustGetwd())
+	if err != nil {
+		return fmt.Errorf("cannot locate selene.toml: %w", err)
+	}
+	manifest, err := project.LoadManifest(root)
+	if err != nil {
+		return err
+	}
+	lockfile, err := project.LoadLockfile(root)
+	if err != nil {
+		return err
+	}
+	modules := project.SortedModules(manifest.Dependencies)
+	if len(modules) == 0 {
+		fmt.Fprintln(os.Stdout, "(no dependencies)")
+		return nil
+	}
+	fmt.Fprintf(os.Stdout, "MODULE\tVERSION\tSOURCE\tCHECKSUM\n")
+	for _, module := range modules {
+		dep := manifest.Dependencies[module]
+		locked, _ := lockfile.Lookup(module)
+		fmt.Fprintf(os.Stdout, "%s\t%s\t%s\t%s\n", module, dep.Version, dep.Source, locked.Checksum)
+	}
+	return nil
+}
+
+func depsVerify(args []string) error {
+	if len(args) != 0 {
+		return errors.New("deps verify does not take additional arguments")
+	}
+	root, err := project.FindRoot(mustGetwd())
+	if err != nil {
+		return fmt.Errorf("cannot locate selene.toml: %w", err)
+	}
+	manifest, err := project.LoadManifest(root)
+	if err != nil {
+		return err
+	}
+	lockfile, err := project.LoadLockfile(root)
+	if err != nil {
+		return err
+	}
+	modules := project.SortedModules(manifest.Dependencies)
+	for _, module := range modules {
+		locked, ok := lockfile.Lookup(module)
+		if !ok {
+			return fmt.Errorf("dependency %s is missing from selene.lock", module)
+		}
+		vendorPath := filepath.Join(root, locked.Vendor)
+		if err := project.VerifyChecksum(vendorPath, locked.Checksum); err != nil {
+			return fmt.Errorf("%s: %w", module, err)
+		}
+	}
+	fmt.Fprintln(os.Stdout, "all dependency checksums verified")
+	return nil
+}
+
+func dumpTokens(filename string) error {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", filename, err)
+	}
+	l := lexer.New(string(content))
+	for tok := l.NextToken(); tok.Type != token.EOF; tok = l.NextToken() {
+		fmt.Printf("%s\t%q\n", tok.Type, tok.Literal)
+	}
+	return nil
+}
+
+func executeFile(rt *runtime.Runtime, filename string) error {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", filename, err)
+	}
+	l := lexer.New(string(content))
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if errs := p.Errors(); len(errs) > 0 {
+		return fmt.Errorf("parse error:\n%s", strings.Join(errs, "\n"))
+	}
+	if _, err := rt.Run(program); err != nil {
+		return fmt.Errorf("runtime error: %w", err)
+	}
+	return nil
+}
+
+func loadDependencies(rt *runtime.Runtime, entry string) error {
+	abs, err := filepath.Abs(entry)
+	if err != nil {
+		return err
+	}
+	root, err := project.FindRoot(filepath.Dir(abs))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	manifest, err := project.LoadManifest(root)
+	if err != nil {
+		return err
+	}
+	if len(manifest.Dependencies) == 0 {
+		return nil
+	}
+	lockfile, err := project.LoadLockfile(root)
+	if err != nil {
+		return err
+	}
+	modules := project.SortedModules(manifest.Dependencies)
+	for _, module := range modules {
+		dep := manifest.Dependencies[module]
+		locked, ok := lockfile.Lookup(module)
+		if !ok {
+			return fmt.Errorf("dependency %s is not recorded in selene.lock", module)
+		}
+		vendorPath := filepath.Join(root, locked.Vendor)
+		if err := project.VerifyChecksum(vendorPath, locked.Checksum); err != nil {
+			return fmt.Errorf("%s: %w", module, err)
+		}
+		if err := loadVendoredModule(rt, module, vendorPath); err != nil {
+			return fmt.Errorf("%s@%s: %w", module, dep.Version, err)
+		}
+	}
+	return nil
+}
+
+func loadVendoredModule(rt *runtime.Runtime, modulePath, vendorPath string) error {
+	files, err := project.ListSeleneFiles(vendorPath)
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("no .selene files found in %s", vendorPath)
+	}
+	depRuntime := runtime.New()
+	for _, file := range files {
+		if err := executeFile(depRuntime, file); err != nil {
+			return err
+		}
+	}
+	exports := depRuntime.Environment().Snapshot()
+	for _, builtin := range []string{"print", "format", "spawn", "channel", "__package__"} {
+		delete(exports, builtin)
+	}
+	moduleVal := runtime.NewModule(lastSegment(modulePath), exports)
+	attachModule(rt.Environment(), modulePath, moduleVal)
+	return nil
+}
+
+func attachModule(env *runtime.Environment, modulePath string, moduleVal *runtime.Module) {
+	segments := strings.Split(modulePath, "/")
+	if len(segments) == 0 {
+		return
+	}
+	current := moduleVal
+	for i := len(segments) - 2; i >= 0; i-- {
+		parent := runtime.NewModule(segments[i], map[string]runtime.Value{segments[i+1]: current})
+		current = parent
+	}
+	rootName := segments[0]
+	if existing, ok := env.Get(rootName); ok {
+		if existingModule, ok := existing.(*runtime.Module); ok {
+			mergeModules(existingModule, current)
+		} else {
+			env.Set(rootName, current)
+		}
+	} else {
+		env.Set(rootName, current)
+	}
+	env.Set(segments[len(segments)-1], moduleVal)
+}
+
+func mergeModules(target, source *runtime.Module) {
+	if target.Exports == nil {
+		target.Exports = make(map[string]runtime.Value)
+	}
+	keys := make([]string, 0, len(source.Exports))
+	for name := range source.Exports {
+		keys = append(keys, name)
+	}
+	sort.Strings(keys)
+	for _, name := range keys {
+		val := source.Exports[name]
+		if existing, ok := target.Exports[name]; ok {
+			tMod, tOK := existing.(*runtime.Module)
+			sMod, sOK := val.(*runtime.Module)
+			if tOK && sOK {
+				mergeModules(tMod, sMod)
+				continue
+			}
+		}
+		target.Exports[name] = val
+	}
+}
+
+func lastSegment(path string) string {
+	if path == "" {
+		return ""
+	}
+	parts := strings.Split(path, "/")
+	return parts[len(parts)-1]
+}
+
+func mustGetwd() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	return wd
+}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,3 @@
+title: Selene Language
+description: Experimental programming language tooling implemented in Go.
+theme: jekyll-theme-minimal

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,0 +1,103 @@
+---
+layout: default
+title: Embedding Selene
+---
+
+# Embedding Selene
+
+Selene's lexer, parser, and interpreter are exposed as Go packages. This guide shows how to execute Selene code from your own
+applications and extend the runtime with custom functionality.
+
+## Running a script from Go
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+
+    "selenelang/internal/lexer"
+    "selenelang/internal/parser"
+    "selenelang/internal/runtime"
+)
+
+func main() {
+    script, err := os.ReadFile("examples/hello.selene")
+    if err != nil {
+        panic(err)
+    }
+
+    l := lexer.New(string(script))
+    p := parser.New(l)
+    program := p.ParseProgram()
+    if errs := p.Errors(); len(errs) > 0 {
+        panic(errs)
+    }
+
+    rt := runtime.New()
+    if _, err := rt.Run(program); err != nil {
+        panic(err)
+    }
+
+    fmt.Println("script executed successfully")
+}
+```
+
+The runtime evaluates statements sequentially and returns the value of the last expression. Errors produced during parsing or
+evaluation bubble back as Go `error` values so you can integrate Selene into larger systems safely.
+
+## Sharing environments
+
+When embedding Selene you can reuse a single runtime to keep global state alive across multiple scripts:
+
+```go
+rt := runtime.New()
+
+for _, path := range []string{"config.selene", "startup.selene"} {
+    if err := runScript(rt, path); err != nil {
+        panic(err)
+    }
+}
+```
+
+Each script receives the same top-level environment, making it easy to build REPLs or plugin systems.
+
+## Adding custom builtins
+
+Expose host functionality by injecting new built-in functions into the runtime environment:
+
+```go
+rt := runtime.New()
+rt.Environment().Set("now", runtime.NewBuiltin("now", func(args []runtime.Value) (runtime.Value, error) {
+    return runtime.NewString(time.Now().Format(time.RFC3339)), nil
+}))
+```
+
+Selene scripts can now call `now()` to retrieve timestamps from the host application.
+Remember to import Go's standard-library `time` package in the host program.
+
+The default runtime already includes a handful of helpers—`print`, `format`, `spawn`, and `channel`. You can freely mix these
+with your own builtins to expose logging, metrics, or IO capabilities to scripts.
+
+## Handling results
+
+A Selene program returns the last evaluated value. Use this to send structured data back to Go:
+
+```go
+result, err := rt.Run(program)
+if err != nil {
+    return err
+}
+
+fmt.Println("program produced:", result.Inspect())
+```
+
+Objects and arrays map cleanly onto Selene's native composite types, making it straightforward to implement serialization or
+configuration pipelines.
+
+## Embedding tips
+
+- Compile Selene scripts ahead of time if you need to detect syntax errors early.
+- Wrap runtime execution in context-aware cancellation if scripts may run for an extended period.
+- Pair Selene with Go's templating or HTTP packages to build dynamic configuration and scripting environments.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,519 @@
+---
+layout: default
+title: Example Scripts
+---
+
+# Example scripts
+
+Selene ships with runnable scripts that illustrate different language features. Execute any of them with `selene path/to/script.selene`.
+
+## Greeting
+
+**File:** `examples/hello.selene`
+
+Introduces bindings, expression-bodied functions, and printing.
+
+```selene
+let greeting: String = "Hello";
+
+fn greet(name: String): String => greeting + ", " + name;
+
+fn main() {
+    print(greet("Selene"));
+}
+
+main();
+```
+
+## Math utilities
+
+**File:** `examples/math.selene`
+
+Shows how to organize reusable arithmetic helpers and compose functions.
+
+```selene
+let pi: Number = 314159 / 100000;
+
+fn circleArea(radius: Number): Number => radius * radius * pi;
+fn circumference(radius: Number): Number => 2 * pi * radius;
+
+fn report(name: String, radius: Number) {
+    let area = circleArea(radius);
+    let edge = circumference(radius);
+    print(name + " => area=" + area + ", circumference=" + edge);
+}
+
+report("small", 2);
+report("medium", 5);
+report("large", 9);
+```
+
+## Collections and objects
+
+**File:** `examples/collections.selene`
+
+Demonstrates arrays, objects, optional chaining, Elvis expressions, and string indexing.
+
+```selene
+let toolkit = {
+    name: "Selene",
+    version: "0.1.0",
+    features: ["lexer", "parser", "runtime", "docs"],
+    maintainer: null
+};
+
+fn describeToolkit() {
+    print("name => " + toolkit.name);
+    print("version => " + toolkit.version);
+    print("first feature => " + toolkit.features[0]);
+    let maintainer = toolkit.maintainer?.name ?: "Community";
+    print("maintainer => " + maintainer);
+    print("version major => " + toolkit.version[0]);
+}
+
+describeToolkit();
+```
+
+## Optional access patterns
+
+**File:** `examples/options.selene`
+
+Highlights optional chaining, Elvis defaults, and the non-null assertion when navigating nested data.
+
+```selene
+let profile = {
+    name: "Nova",
+    contact: {
+        email: "nova@example.com",
+        address: null
+    }
+};
+
+let email = profile.contact?.email ?: "unknown@selene.dev";
+print("Email: " + email);
+
+let city = profile.contact?.address?.city ?: "Unknown";
+print("City: " + city);
+
+let safeContact = profile.contact!!;
+print("Forced contact email: " + safeContact.email);
+```
+
+## Pattern matching
+
+**File:** `examples/patterns.selene`
+
+Uses `match` statements with object destructuring to branch on structured data.
+
+```selene
+let shapes = [
+    { kind: "circle", radius: 2 },
+    { kind: "square", side: 4 },
+    { kind: "triangle", base: 3, height: 4 }
+];
+
+fn describe(shape: Any) {
+    match shape {
+        { kind: "circle", radius: r } => print("Circle with radius " + r);
+        { kind: "square", side: s } => print("Square with side " + s);
+        other => print("Unknown shape kind " + (other.kind ?: "n/a"));
+    }
+}
+
+print("Cataloging shapes:");
+describe(shapes[0]);
+describe(shapes[1]);
+describe(shapes[2]);
+```
+
+## Recursive helpers
+
+**File:** `examples/recursion.selene`
+
+Demonstrates using `match` clauses to implement recursion-driven control flow without loops.
+
+```selene
+fn factorial(n: Number) {
+    match n {
+        0 => 1;
+        1 => 1;
+        value => value * factorial(value - 1);
+    }
+}
+
+print("Factorial results:");
+print("5! = " + factorial(5));
+print("7! = " + factorial(7));
+```
+
+## Control flow in action
+
+**File:** `examples/control.selene`
+
+Walks through `if`/`else`, `for`/`while`, and the `return`/`break`/`continue` statements.
+
+```selene
+var total = 0;
+
+for (let i = 0; i < 10; i = i + 1) {
+    if i % 2 == 0 {
+        continue;
+    }
+    if i > 7 {
+        break;
+    }
+    total = total + i;
+}
+
+var countdown = 3;
+while countdown > 0 {
+    print("tick", countdown);
+    countdown = countdown - 1;
+}
+
+fn fib(n: Number): Number {
+    if n <= 1 {
+        return n;
+    }
+    return fib(n - 1) + fib(n - 2);
+}
+
+print("total", total);
+print("fib(6)", fib(6));
+
+var attempts = 0;
+while true {
+    attempts = attempts + 1;
+    if attempts == 3 {
+        print("finished after", attempts, "tries");
+        break;
+    }
+}
+```
+
+## Custom types
+
+**File:** `examples/types.selene`
+
+Introduces struct methods, simple classes, enums, and matching on enum cases.
+
+```selene
+struct Point(x: Number, y: Number) {
+    fn describe(): String {
+        return "Point(" + self.x + ", " + self.y + ")";
+    }
+}
+
+class Greeter(name: String) {
+    fn greet(target: String): String {
+        return self.name + ", " + target;
+    }
+}
+
+enum Option {
+    Some(value: Number);
+    None;
+}
+
+let origin = Point(0, 0);
+let greeter = Greeter("Selene");
+let value = Option.Some(41);
+
+print(origin.describe());
+print(greeter.greet("friend"));
+
+match value {
+    Some(v) => print("value + 1 =", v + 1);
+    None => print("no value");
+}
+```
+
+## Modules and imports
+
+**File:** `examples/modules.selene`
+
+Shows how to export helpers from a module and import them elsewhere in the same script using identifier-based paths.
+
+```selene
+module math_utils {
+    fn square(n: Number): Number => n * n;
+    let constants = { tau: 6.28318 };
+}
+
+import math_utils.square;
+import math_utils.constants as consts;
+
+print(square(5));
+print("tau ≈", consts.tau);
+```
+
+## Packages and augmented assignment
+
+**File:** `examples/packages.selene`
+
+Adds a package header to the file, imports a module using Go-style string syntax with an alias, and demonstrates the `+=`, `-=`, `*=`, `/=`, and `%=` operators.
+
+```selene
+package main;
+
+module math_utils {
+    fn increment(n: Number): Number => n + 1;
+    fn triple(n: Number): Number => n * 3;
+}
+
+import utils "math_utils";
+
+fn compute(value: Number): Number {
+    var result = value;
+    result += utils.increment(value);
+    result *= 2;
+    result -= 4;
+    result /= 3;
+    result %= 5;
+    return result;
+}
+
+fn main() {
+    let start = 6;
+    var score = start;
+    score += 2;
+    score *= 3;
+    print("score:", score);
+    print("compute(score):", compute(score));
+}
+
+main();
+```
+
+## Vendored dependency imports
+
+**File:** `examples/dependency.selene`
+
+Imports a module that was vendored into `vendor/` with `selene deps add`, then composes helper functions exported from the dependency.
+
+```selene
+package main;
+
+import math "github.com/selene-lang/richmath";
+
+fn describe(values: Array) {
+    print("values:", values);
+    print("sum:", math.sum(values));
+    print("average:", math.average(values));
+    print("running mean:", math.stats.runningMean(values));
+}
+
+fn main() {
+    describe([2, 4, 6, 8, 10]);
+}
+
+main();
+```
+
+## Contracts and postconditions
+
+**File:** `examples/contracts.selene`
+
+Combines standalone contract declarations with inline function contracts to validate results.
+
+```selene
+contract validators {
+    fn withinRange(value: Number, min: Number, max: Number): Boolean {
+        return value >= min && value <= max;
+    }
+}
+
+fn clamp(value: Number, min: Number, max: Number): Number
+    contract {
+        returns(result) => result >= min;
+        returns(result) => result <= max;
+    }
+{
+    if value < min {
+        return min;
+    }
+    if value > max {
+        return max;
+    }
+    return value;
+}
+
+let values = [ -5, 3, 42 ];
+for (let i = 0; i < values.length; i = i + 1) {
+    let original = values[i];
+    let clamped = clamp(original, 0, 10);
+    print("clamp(" + original + ") => " + clamped);
+    print("within range? => " + validators.withinRange(clamped, 0, 10));
+}
+```
+
+## Strings and formatting
+
+**File:** `examples/strings.selene`
+
+Highlights interpolation, raw/triple-quoted strings, format specifiers, and extension helpers for string processing.
+
+```selene
+ext fn String.reverse(): String {
+    var result = "";
+    var i = this.length - 1;
+    while i >= 0 {
+        result = result + this[i];
+        i -= 1;
+    }
+    return result;
+}
+
+ext fn String.isPalindrome(): Boolean = this == this.reverse();
+
+let name = "Selene";
+print("greeting => ${name}");
+print(r"raw strings keep \\ intact");
+print(f"is palindrome? ${name.isPalindrome():upper}");
+```
+
+## Extension methods
+
+**File:** `examples/extensions.selene`
+
+Adds fluent helpers to existing types with `ext fn`.
+
+```selene
+ext fn Int.squared(): Int = this * this;
+
+let value = 7;
+print("square => " + value.squared());
+```
+
+## Pointer semantics
+
+**File:** `examples/pointers.selene`
+
+Uses `&`/`*` to mutate values through shared references and demonstrate pointer aliasing.
+
+```selene
+let counter = 41;
+let handle = &counter;
+
+fn bump(value: Pointer) {
+    *value += 1;
+}
+
+bump(handle);
+print("counter => " + counter);
+```
+
+## Interfaces and `is`
+
+**File:** `examples/interfaces.selene`
+
+Shows structural conformance, `is` guards, and mixing structs with extension methods.
+
+```selene
+interface Speaker {
+    fn speak(name: String): String;
+}
+
+struct Person(name: String) {
+    fn speak(name: String): String => "Hi, I'm " + name + " (" + self.name + ")";
+}
+
+ext fn String.speak(name: String): String => "Echo from \"" + this + "\" to " + name;
+
+fn introduce(someone: Speaker, name: String) {
+    print(someone.speak(name));
+}
+
+let luna = Person("Luna");
+introduce(luna, "Orion");
+
+let word = "Selene";
+if word is Speaker {
+    introduce(word, "Orion");
+}
+```
+
+## Concurrency primitives
+
+**File:** `examples/concurrency.selene`
+
+Demonstrates `spawn`, channels, and awaiting messages from concurrent tasks.
+
+```selene
+fn count(limit: Int, out: Channel) {
+    var i = 0;
+    while i < limit {
+        out.send(f"tick #${i}");
+        i += 1;
+    }
+    out.close();
+}
+
+let updates = channel();
+spawn(count, 4, updates);
+
+try {
+    while true {
+        print(await updates);
+    }
+} catch (err) {
+    print("updates exhausted");
+}
+
+fn slowAdd(a: Int, b: Int): Int {
+    return a + b;
+}
+
+let task = spawn(slowAdd, 20, 22);
+print("sum from task:", await task);
+```
+
+## Error handling and resource safety
+
+**File:** `examples/errors.selene`
+
+Combines `using`, `try`/`catch`/`finally`, and `throw` to showcase explicit error management.
+
+```selene
+struct Trace(name: String) {
+    fn close() {
+        print("closing", self.name);
+    }
+}
+
+fn risky(flag: Boolean) {
+    if flag {
+        throw "something went wrong";
+    }
+}
+
+using scope = Trace("scope") {
+    try {
+        risky(true);
+    } catch (err) {
+        print("caught:", err);
+    } finally {
+        print("cleanup");
+    }
+}
+```
+
+## Condition dispatch
+
+**File:** `examples/conditions.selene`
+
+Illustrates declarative rule-based branching with `condition` blocks.
+
+```selene
+let shape = { kind: "circle", radius: 5 };
+
+condition {
+    when shape.kind == "circle" => print("Circle area:", 3.14159 * shape.radius * shape.radius);
+    when shape.kind == "rectangle" => print("Rectangle area:", shape.width * shape.height);
+    else => print("Unknown shape type", shape.kind);
+}
+```
+
+## Try your own
+
+Create a new file under `examples/` and run it with the CLI. With modules, functions, structs/classes/enums, pattern matching, and imperative loops, Selene gives you enough building blocks to sketch real control flow.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,109 @@
+---
+layout: default
+title: Getting Started
+---
+
+# Getting started
+
+This guide walks through installing the Selene toolchain, running scripts, and navigating the repository.
+
+## Install prerequisites
+
+- [Go 1.21+](https://go.dev/dl/) for building the CLI and embedding Selene.
+- A terminal with access to standard developer tools.
+
+## Fetch the source
+
+Clone the repository and download dependencies:
+
+```bash
+git clone https://github.com/your-user/selenelang.git
+cd selenelang
+go mod tidy
+```
+
+## Build and install the CLI
+
+Use Go to compile the `selene` executable:
+
+```bash
+go build ./...
+```
+
+Install it into your `$GOBIN` so it is accessible anywhere:
+
+```bash
+go install ./cmd/selene
+```
+
+Verify the installation by checking the version banner:
+
+```bash
+selene --help
+```
+
+You should see usage information describing the `run`, `tokens`, `init`, and `deps` subcommands.
+
+## Run your first script
+
+Execute the bundled greeting example:
+
+```bash
+selene run examples/hello.selene
+```
+
+You should see output similar to:
+
+```
+Hello, Selene
+```
+
+You can also view the raw token stream without executing the script:
+
+```bash
+selene tokens examples/hello.selene
+```
+
+### Scaffold a new project
+
+Generate a manifest, documentation folder, and starter source file in the current directory:
+
+```bash
+selene init github.com/you/stellar-selene --name "stellar-selene"
+```
+
+The command writes `selene.toml`, prepares a `docs/` directory, and places a `src/main.selene` entry point that prints a greeting.
+
+### Vendor dependencies
+
+To depend on another Selene package, vendor it into your project and lock its checksum:
+
+```bash
+selene deps add --path ../richmath --source https://github.com/selene-lang/richmath github.com/selene-lang/richmath v1.0.0
+selene deps list
+selene deps verify
+```
+
+Vendored code is copied into `vendor/` while `selene.lock` records the SHA-256 digest for reproducibility.
+
+## Project layout
+
+```
+cmd/selene/         CLI entry point
+internal/token/     Token definitions and keyword lookup
+internal/lexer/     Scanner producing tokens with positions
+internal/parser/    Pratt parser producing AST nodes
+internal/ast/       AST node structures used by the parser
+internal/runtime/   Tree-walking interpreter and runtime values
+examples/           Sample Selene sources for experimentation
+docs/               Documentation site published via GitHub Pages
+vendor/             Vendored Selene packages managed by selene deps
+selene.toml        Project manifest and dependency metadata
+selene.lock        Locked dependency checksums
+```
+
+## Next steps
+
+- Browse the [language tour](language-tour.md) to see the supported syntax and runtime behavior.
+- Consult the [embedding guide](embedding.md) to run Selene inside your own Go projects.
+- Experiment with the scripts in [examples](examples.md) and try extending them with your own functions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,33 @@
+---
+layout: default
+title: Selene Overview
+---
+
+# Selene Overview
+
+Selene is an experimental programming language toolkit implemented in Go. The lexer, parser, and runtime work together to let you
+prototype new language ideas, embed Selene as a scripting language, or analyze Selene source code programmatically.
+
+## Quick links
+
+- [Getting started](getting-started.md) – install the CLI, run scripts, and understand the project layout.
+- [Language tour](language-tour.md) – explore Selene syntax, expression forms, and runtime semantics.
+- [Language reference](reference.md) – browse every construct recognized by the lexer, parser, and runtime.
+- [Embedding guide](embedding.md) – execute Selene code from your own Go applications.
+- [Example scripts](examples.md) – curated walkthroughs of the sample programs included in the repository.
+
+## What you can build today
+
+The current runtime covers expression evaluation, pattern matching, first-class functions, package headers, modules with Go-style imports, user-defined types, and imperative control flow with augmented assignment helpers. Recent updates add pointer semantics, structural interfaces, extension methods, rich string interpolation/formatting (including raw and triple-quoted literals), resource-safe `using` statements, `try`/`catch`/`finally` with `throw`, lightweight concurrency (`spawn`, `channel`, `await`), rule-driven `condition { when ... }` dispatch, and secure dependency vendoring backed by `selene.toml`/`selene.lock` manifests.
+Combine these building blocks—`if`/`for`/`while`, structs/classes/enums, pattern-matching, interfaces, concurrency primitives, and vendored packages—to sketch real-world scripts. The standard library remains intentionally tiny so you can experiment with your own runtime helpers or pull in external Selene modules with deterministic checksums.
+
+## Publishing the docs
+
+To publish this site with GitHub Pages:
+
+1. Push the repository to GitHub.
+2. Open **Settings → Pages**.
+3. Choose the `main` branch and the `/docs` folder.
+4. Save your changes and wait for GitHub to build the static site.
+
+Once deployed you will have a hosted reference for the language, examples, and integration guidance.

--- a/docs/language-tour.md
+++ b/docs/language-tour.md
@@ -1,0 +1,425 @@
+---
+layout: default
+title: Language Tour
+---
+
+# Language tour
+
+Selene emphasizes expression-oriented programming with a concise syntax. This tour highlights the features implemented in the
+current interpreter so you can design scripts and DSLs with confidence.
+
+## Literals and bindings
+
+Selene supports numbers, strings, booleans, and null. Bindings are introduced with `let` and are immutable by default:
+
+```selene
+let greeting: String = "Hello";
+let version: Number = 1;
+let debug: Boolean = true;
+let missing = null;
+```
+
+Bindings are looked up dynamically at runtime. Type annotations are optional but help document intent.
+
+## Arithmetic and comparison
+
+Numbers participate in the standard arithmetic and comparison operators:
+
+```selene
+let radius = 5;
+let area = radius * radius * (314159 / 100000);
+let isLarge = area > 50;
+print("area => " + area);
+print("large? " + isLarge);
+```
+
+## Functions
+
+Define functions with `fn`. They close over the lexical environment and may use expression bodies (`=>`) or block bodies:
+
+```selene
+fn double(value: Number): Number => value * 2;
+
+fn describe(name: String, value: Number) {
+    let doubled = double(value);
+    print(name + " => " + doubled);
+}
+
+describe("sample", 21);
+```
+
+Functions return the value of their last expression, or you can use `return` to exit early from a block-bodied function.
+
+## Arrays and objects
+
+Use brackets for arrays and braces for objects. Indexing works on arrays and strings:
+
+```selene
+let features = ["lexer", "parser", "runtime"];
+let project = {
+    name: "Selene",
+    items: features
+};
+
+print(project.name);
+print("first feature => " + project.items[0]);
+print("first letter => " + project.name[0]);
+```
+
+Arrays and strings expose a `length` property for quick sizing.
+
+## Optional chaining and Elvis operator
+
+Member lookups can be made optional with `?.`. Combine this with the Elvis operator `?:` to provide defaults when values are
+null (or become null after an optional access):
+
+```selene
+let config = { name: "Selene", owner: null };
+let owner = config.owner?.name ?: "Unknown";
+print("owner => " + owner);
+```
+
+## Strings and formatting
+
+Selene offers several string literal forms:
+
+- Standard quoted strings support escapes and interpolation with `${ ... }`.
+- Format strings start with `f"..."` and accept inline format specifiers like `${value | upper}`.
+- Triple-quoted strings (`""" ... """`) preserve indentation and newlines.
+- Raw strings are prefixed with `r"..."` or `r"""..."""` and do not treat escapes specially.
+
+```selene
+let name = "Selene";
+let standard = "Hello, ${name}!";
+let formatted = f"{name | upper} => ${3.14159 | %.2f}";
+let multiline = """
+Line one
+Line two with ${name}
+""";
+let raw = r"C:\\Users\\demo";
+
+print(standard);
+print(formatted);
+print(multiline);
+print(raw);
+```
+
+`f""` format specifiers understand transformations such as `upper`, `lower`, `title`, `trim`, and printf-style numeric codes.
+
+## Pattern matching
+
+`match` statements provide a flexible way to branch on literals, bind values, and destructure objects. Each clause pattern is tested in order until one matches, and the body of the matching clause produces the statement result:
+
+```selene
+fn describe(shape: Any) {
+    match shape {
+        { kind: "circle", radius: r } => "circle => " + r;
+        { kind: "square", side: s } => "square => " + s;
+        other => "unknown => " + (other.kind ?: "n/a");
+    }
+}
+
+print(describe({ kind: "circle", radius: 3 }));
+```
+
+Patterns may be simple literals (matched by value), identifiers (which bind to the target), object destructuring clauses that recursively match nested shapes, or struct patterns such as `Point(x, y)` that match constructor calls (including enum cases) by position.
+
+## Control flow
+
+Selene offers familiar imperative control flow. Use `if` for branching and `for`/`while` for iteration. `return`, `break`, and `continue` behave as you would expect from other languages. Mutable bindings can take advantage of the augmented assignment operators (`+=`, `-=`, `*=`, `/=`, `%=`) to update values concisely:
+
+```selene
+var total = 0;
+
+for (let i = 0; i < 5; i = i + 1) {
+    if i % 2 == 0 {
+        continue;
+    }
+    total += i;
+}
+
+while total > 4 {
+    total -= 1;
+    if total == 6 {
+        break;
+    }
+}
+
+fn describe(value: Number): String {
+    if value > 4 {
+        return "large";
+    }
+    return "small";
+}
+
+print("summary => " + describe(total));
+```
+
+## Extension functions
+
+Use `ext fn` to add behavior to existing types without modifying their original declarations. Extension methods receive the
+receiver as `this` inside the body and can leverage other helpers in scope:
+
+```selene
+ext fn String.reverse(): String = this.chars().reverse().join("");
+
+ext fn String.isPalindrome(): Boolean = this == this.reverse();
+
+ext fn Int.squared(): Int = this * this;
+
+print("level".isPalindrome());
+print(9.squared());
+```
+
+## Pointers and references
+
+The runtime models pointers explicitly. Use `&` to capture the address of an identifier in scope and `*` to read or assign
+through a pointer. This enables by-reference helpers without introducing classes:
+
+```selene
+var left = 1;
+var right = 2;
+
+fn swap(a: Pointer, b: Pointer) {
+    let temp = *a;
+    *a = *b;
+    *b = temp;
+}
+
+swap(&left, &right);
+print("left => " + left + ", right => " + right);
+```
+
+Pointers can only be created for identifiers that exist in the current environment, preventing dangling references.
+
+## Interfaces and type checks
+
+Interfaces describe structural requirements. A value conforms when it supplies the listed members. Use `is`/`!is` to test
+conformance at runtime:
+
+```selene
+interface Greets {
+    fn greet(name: String): String;
+}
+
+class Robot(id: String) {
+    fn greet(name: String): String {
+        return f"#{id} greets ${name}";
+    }
+}
+
+let bot = Robot("rx-1");
+print("is interface => " + (bot is Greets));
+if bot is Greets {
+    print(bot.greet("Selene"));
+}
+```
+
+Extension functions may also satisfy interfaces by contributing the required members to existing types.
+
+## Resource safety with `using`
+
+`using` ensures resources are closed automatically. The target expression must expose a `close()` function (or Go-style `Close()`
+method when embedding):
+
+```selene
+struct Trace(name: String) {
+    fn close() {
+        print("closing", self.name);
+    }
+}
+
+fn open(name: String): Trace {
+    print("opening", name);
+    return Trace(name);
+}
+
+using scope = open("session.log") {
+    print("work inside using");
+}
+```
+
+When execution leaves the block—because of a return, throw, or normal completion—the resource is closed exactly once.
+
+## Error handling
+
+Handle failure paths explicitly with `try`/`catch`/`finally` and `throw`. The runtime propagates errors until a matching `catch`
+intercepts them. `finally` always runs, even if a catch rethrows a new error:
+
+```selene
+fn parseNumber(text: String): Number {
+    try {
+        return text.toNumber();
+    } catch (err) {
+        print("failed: " + err.message);
+        throw err;
+    } finally {
+        print("parse attempt complete");
+    }
+}
+```
+
+Wrap the identifier in parentheses to bind the thrown value inside a `catch` clause.
+
+## Concurrency primitives
+
+`spawn` launches a function asynchronously and returns a task handle. Create channels with `channel()` and coordinate producers
+and consumers using `send`/`recv`. Await the result of a spawned task or the next value from a channel with `await`:
+
+```selene
+fn produce(out: Channel) {
+    var i = 0;
+    while i < 3 {
+        out.send(f"tick #${i}");
+        i += 1;
+    }
+    out.close();
+}
+
+let ch = channel();
+let worker = spawn(produce, ch);
+
+try {
+    while true {
+        print(await ch);
+    }
+} catch (err) {
+    print("channel closed");
+}
+
+await worker;
+```
+
+Channels signal completion by raising an error from `recv()` (and therefore `await channel`) when closed, making them easy to
+integrate with `try` blocks.
+
+## Condition dispatch
+
+`condition` blocks offer rule-based, object-oriented dispatch. Each `when` guard checks a predicate; the first truthy guard runs
+its body. An optional `else` clause handles the fallback:
+
+```selene
+let order = { total: 120 };
+
+condition {
+    when order.total > 100 => print("VIP shipping");
+    when order.total > 0 => print("Standard shipping");
+    else => print("Empty order");
+}
+```
+
+This pattern keeps complex branching logic declarative and readable. Guards execute in the surrounding scope, so any identifier
+referenced within `when` clauses must already be defined.
+
+## Packages, modules, and imports
+
+Start a script with an optional `package` header to label its namespace. Group related helpers inside a `module` and import them elsewhere in the file. Everything defined inside the module body is exported automatically, and you can import exports either by identifier path or via Go-style string syntax:
+
+```selene
+package analytics;
+
+module math_utils {
+    fn square(n: Number): Number => n * n;
+    let constants = { tau: 6.28318 };
+}
+
+import math_utils.square;
+import utils "math_utils";
+
+print(square(5));
+print("tau => " + utils.constants.tau);
+```
+
+When you need code that lives outside the current repository, use the `selene deps` commands to vendor it into `vendor/` and record the checksum in `selene.lock`. Once vendored, string imports support full module paths such as `"github.com/selene-lang/richmath"`, and Selene will make the exported modules available at runtime:
+
+```selene
+import math "github.com/selene-lang/richmath";
+
+print(math.average([1, 2, 3]));
+```
+
+## Contracts
+
+Use `contract { ... }` blocks to attach postconditions to functions. Each `returns(condition)` clause evaluates after the
+function body with a special `result` binding that contains the returned value. If a condition is falsy, Selene raises a
+runtime error. Contracts can also capture parameters or other locals from the definition site:
+
+```selene
+fn clamp(value: Number, min: Number, max: Number): Number
+    contract {
+        returns(result) => result >= min;
+        returns(result) => result <= max;
+    }
+{
+    if value < min {
+        return min;
+    }
+    if value > max {
+        return max;
+    }
+    return value;
+}
+
+print("clamp(42, 0, 10) => " + clamp(42, 0, 10));
+```
+
+Separate `contract` declarations create reusable bundles of helpers that can be accessed via dot syntax similar to modules.
+
+## Structs, classes, and enums
+
+Define your own data types with `struct`, `class`, and `enum`. Struct and class constructors behave like functions, and methods gain access to the current instance through `self`:
+
+```selene
+struct Point(x: Number, y: Number) {
+    fn describe(): String {
+        return "Point(" + self.x + ", " + self.y + ")";
+    }
+}
+
+class Greeter(name: String) {
+    fn greet(target: String): String {
+        return self.name + ", " + target;
+    }
+}
+
+enum Option {
+    Some(value: Number);
+    None;
+}
+
+let value = Option.Some(41);
+print(Point(2, 3).describe());
+print(Greeter("Selene").greet("friend"));
+
+match value {
+    Some(v) => print("value + 1 =" + (v + 1));
+    None => print("no value");
+}
+```
+
+## Function application and scoping
+
+Functions capture the environment in which they are defined:
+
+```selene
+let prefix = "[Selene]";
+
+fn makeLogger(label: String) {
+    fn log(message: String) {
+        print(prefix + " " + label + ": " + message);
+    }
+
+    log("logger ready");
+}
+
+makeLogger("demo");
+```
+
+Each function call receives a fresh scope for its parameters, ensuring predictable lexical scoping.
+
+## Limitations and roadmap
+
+Selene remains intentionally small: numbers are all 64-bit floats, property assignment on objects and instances is still
+restricted, and the standard library only includes a handful of helpers (`print`, `format`, `spawn`, `channel`, etc.). The
+concurrency runtime is lightweight and best suited for demos rather than high-performance workloads. Future iterations may grow
+the builtin ecosystem, expand mutation helpers for structured data, and optimize the interpreter pipeline.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,137 @@
+---
+layout: default
+title: Language Reference
+---
+
+# Selene language reference
+
+This reference catalogs the syntax recognized by the Selene lexer and parser, along with notes on what the runtime executes today. Use it to cross-check constructs while writing scripts or building tooling on top of the Selene frontend.
+
+## Lexical structure
+
+- **Whitespace** – spaces, tabs, and newlines separate tokens but are otherwise ignored.
+- **Comments** – `//` starts a line comment that runs to the end of the line. `/* ... */` forms a block comment and may span multiple lines. Comments are skipped by the lexer and do not nest.
+- **Identifiers** – start with an ASCII letter or underscore and may contain ASCII letters, digits, or underscores. Identifiers are case-sensitive.
+- **Keywords** – `let`, `var`, `fn`, `async`, `contract`, `returns`, `class`, `struct`, `enum`, `match`, `module`, `import`, `as`, `package`, `interface`, `ext`, `if`, `else`, `while`, `for`, `return`, `break`, `continue`, `true`, `false`, `null`, `is`, `await`, `try`, `catch`, `finally`, `throw`, `using`, `condition`, and `when`.
+- **Operators** – arithmetic (`+`, `-`, `*`, `/`, `%`), comparison (`==`, `!=`, `<`, `<=`, `>`, `>=`), logical (`&&`, `||`, `!`), assignment (`=`, `+=`, `-=`, `*=`, `/=`, `%=`), Elvis (`?:`), member access (`.`), optional chaining (`?.`), non-null assertion (`!!`), type tests (`is`, `!is`), pointer capture (`&`), indexing (`[]`), call application (`()`), and the pattern arrow (`=>`).
+
+## Literals
+
+- **Numbers** – sequences of digits optionally containing a single decimal point (e.g. `42`, `3.14`). All numbers are stored as 64-bit floating point values at runtime.
+- **Strings** – delimited by double quotes and supporting escape sequences and interpolation via `${ expression }`. Prefix with `f` to enable inline format specifiers (`f"{name | upper}"`), or prefix with `r` to treat backslashes literally. Triple-quoted forms (`"""..."""`) preserve indentation and line breaks.
+- **Booleans** – the keywords `true` and `false`.
+- **Null** – represented by the keyword `null`.
+- **Arrays** – bracketed collections such as `[1, 2, 3]`. Elements evaluate from left to right.
+- **Objects** – brace-delimited key/value maps like `{ name: "Selene", version: "0.1.0" }`. Keys may be bare identifiers or string literals.
+
+## Declarations
+
+### Variable bindings
+
+- `let name = expression;` creates an immutable binding.
+- `var name = expression;` creates a mutable binding that may be reassigned later with `name = newValue`.
+- Optional type annotations may appear after the identifier: `let count: Number = 3;`. Types are parsed but not enforced by the runtime yet.
+
+### Functions and extensions
+
+```
+fn name(parameters) [ : ReturnType ] [async] [contract { ... }] { ... }
+fn name(parameters) [ : ReturnType ] [async] [contract { ... }] => expression;
+ext fn Receiver.name(parameters) [ : ReturnType ] { ... }
+ext fn Receiver.name(parameters) [ : ReturnType ] => expression;
+```
+
+- Parameters are comma-separated identifiers that may also include type annotations (parsed only).
+- Bodies can be expression-bodied (`=>`) or block-bodied (`{ ... }`). Expression bodies implicitly become the function result.
+- Functions close over the lexical environment in which they are defined.
+- `async` marks a function for future asynchronous execution but currently runs synchronously. Contract clauses are enforced
+  after the function body completes: each `returns(condition)` entry evaluates the optional guard/condition with a `result`
+  binding that contains the function's return value. A falsy condition triggers a runtime error.
+- Extension functions (`ext fn`) attach new methods to existing types. Inside the body the receiver is available as `this`.
+
+### Package headers
+
+- `package identifier;` labels the current file with a package name. The runtime records the package under the `__package__` binding for introspection but otherwise treats it as metadata.
+
+### Modules and imports
+
+```
+module Identifier {
+    // nested declarations and statements
+}
+
+import foo.bar as baz;
+import alias "module_path";
+```
+
+- Modules execute in their own lexical scope and export every binding defined in the body. `import` pulls values from a module (optionally drilling into nested properties) and binds them into the current scope. Provide an alias either before a string literal (`import helpers "math_utils";`) or with an `as` clause (`import math_utils.constants as consts;`). String import paths split on `/` so you can traverse nested exports.
+
+### Classes, structs, enums, interfaces, and contracts
+
+```
+class Name(params) [ : Super ] { ... }
+struct Name(params) { ... }
+enum Name { CaseOne; CaseTwo(value); }
+interface Name { fn method(params): ReturnType; }
+contract Name { ... }
+```
+
+- Struct and class declarations introduce callable constructors. Struct instances expose their fields and methods via `self`. Class declarations optionally inherit methods and static values from a superclass. Enum declarations generate constructor functions for each case that produce tagged union values. Contract declarations produce reusable bundles of declarations that can be accessed with dot syntax (similar to modules), and inline function contracts are enforced when the function returns.
+- Interfaces describe structural requirements. Any value that supplies the listed members conforms automatically. Use the `is`/`!is` operators at runtime to check conformance.
+
+## Statements
+
+- **Expression statement** – any expression followed by an optional semicolon. The value of the expression becomes the statement result.
+- **Block** – `{ statement* }` introduces a new lexical scope and returns the value of the last statement inside the block.
+- **If statement** – `if condition { ... } [else statement]` executes the first branch whose condition is truthy. `else if` chains are written as `else` followed by another `if` statement.
+- **While loop** – `while condition { ... }` repeats the body while the condition evaluates to a truthy value.
+- **For loop** – `for (initializer; condition; post) { ... }` executes the initializer once, evaluates the condition before each iteration, and runs the post expression after each iteration.
+- **Match statement** – `match expression { pattern => statement; ... }` evaluates the target expression, tries each pattern in order, and executes the body of the first successful match. The value produced by the body becomes the statement result. If no patterns match, the statement yields `null`.
+- **Return statement** – `return expression?;` exits the innermost function. Without an expression the function returns `null`.
+- **Break/continue** – `break;` exits the nearest loop; `continue;` skips directly to the next iteration.
+- **Using statement** – `using name = expression statement` evaluates the expression, binds it to `name`, runs `statement`, and then calls `name.close()` (or `Close()` when embedding Go values) when the statement completes.
+- **Try statement** – `try { ... } [catch (identifier) { ... }] [finally { ... }]` wraps execution of the body and intercepts errors. Parenthesize the identifier to capture the thrown value. `finally` is optional and executes regardless of success or failure.
+- **Condition statement** – `condition { when guard => statement; ... [else => statement;] }` evaluates each guard in order and executes the first matching body. `else` handles the fallback case.
+- **Throw statement** – `throw expression;` raises an error. If no `try`/`catch` intercepts it, the runtime terminates execution with a diagnostic.
+
+## Patterns
+
+Selene patterns appear inside `match` statements.
+
+- **Identifier pattern** – `name` binds the matched value to a fresh identifier within the case body.
+- **Literal pattern** – any literal expression (`0`, `"text"`, `true`, `null`, etc.) that matches by value.
+- **Object pattern** – `{ key: subpattern, other: anotherPattern }` destructures object properties recursively. Keys may use identifier or string syntax.
+- **Struct pattern** – `Point(x, y)` matches struct and class instances created by `Point` and binds their positional fields. It also matches enum cases with the same name, binding the case parameters.
+
+## Expressions
+
+- **Primary expressions** – identifiers, literals, array/object literals, and grouped expressions `( ... )`.
+- **Unary operators** – `-expr`, `+expr`, `!expr`, `&identifier` (address-of), and `*pointer` (dereference).
+- **Binary operators** – addition, subtraction, multiplication, division, modulo, comparisons, equality, logical `&&`/`||`, and Elvis `?:`.
+- **Assignments** – `name = expression` updates an existing binding created with `var`. Compound assignments (`+=`, `-=`, `*=`, `/=`, `%=`) combine an arithmetic operation with a re-assignment.
+- **Function calls** – `callee(arg1, arg2)` evaluate the callee then its arguments left to right.
+- **Indexing** – `array[index]` or `string[index]`.
+- **Member access** – `object.property`, optional chaining `object?.property`, and non-null assertions `expression!!`. Arrays and strings expose a read-only `length` property.
+- **Pointer operators** – `&identifier` captures a pointer to an existing binding and `*pointer` dereferences it for reading or assignment.
+- **Await expression** – `await expression` waits on a spawned task or channel, or simply returns its operand when used with other values.
+- **Type checks** – `value is InterfaceName` and `value !is InterfaceName` perform structural interface conformance tests.
+- **Throw expression** – `throw expression` raises a runtime error; it can appear either as a stand-alone statement or inside expressions.
+
+## Runtime support summary
+
+- The interpreter executes:
+
+- Variable declarations, assignments (including `+=`, `-=`, `*=`, `/=`, `%=`), and lexical scoping.
+- Package declarations, modules, imports (identifier chains or string paths), and nested scopes.
+- Function declarations, first-class closures, extension methods, expression/block bodies, and inline contracts.
+- Struct, class, enum, and interface declarations with instance methods and structural conformance checks.
+- Arrays, objects, arithmetic, comparisons, logical operators, Elvis expressions, optional chaining, string interpolation/formatting, and non-null assertions.
+- Control flow including `if`/`else`, `for`, `while`, `return`, `break`, and `continue`.
+- Match statements with identifier, literal, object, and struct/enum patterns.
+- Using statements, try/catch/finally, throw expressions, and resource-safe cleanup.
+- Pointer semantics (`&`/`*`) with safe aliasing.
+- Lightweight concurrency primitives: `spawn` for goroutine-backed tasks, buffered/unbuffered channels with `send`/`recv`, and `await` for awaiting tasks or channel messages.
+- Condition dispatch blocks for rule-driven branching.
+- Built-in helpers including `print`, `format`, `spawn`, and `channel`.
+
+Refer to the [example scripts](examples.md) for runnable demonstrations of the supported features.

--- a/examples/collections.selene
+++ b/examples/collections.selene
@@ -1,0 +1,18 @@
+// Showcase arrays, objects, optional chaining, and indexing.
+let toolkit = {
+    name: "Selene",
+    version: "0.1.0",
+    features: ["lexer", "parser", "runtime", "docs"],
+    maintainer: null
+};
+
+fn describeToolkit() {
+    print("name => " + toolkit.name);
+    print("version => " + toolkit.version);
+    print("first feature => " + toolkit.features[0]);
+    let maintainer = toolkit.maintainer?.name ?: "Community";
+    print("maintainer => " + maintainer);
+    print("version major => " + toolkit.version[0]);
+}
+
+describeToolkit();

--- a/examples/concurrency.selene
+++ b/examples/concurrency.selene
@@ -1,0 +1,29 @@
+package examples
+
+fn count(limit: Int, out: Channel) {
+    var i = 0;
+    while i < limit {
+        out.send(f"tick #${i}");
+        i += 1;
+    }
+    out.close();
+}
+
+let updates = channel();
+spawn(count, 4, updates);
+
+try {
+    while true {
+        let message = await updates;
+        print(message);
+    }
+} catch (err) {
+    print("updates exhausted");
+}
+
+fn slowAdd(a: Int, b: Int): Int {
+    return a + b;
+}
+
+let task = spawn(slowAdd, 20, 22);
+print("sum from task:", await task);

--- a/examples/conditions.selene
+++ b/examples/conditions.selene
@@ -1,0 +1,23 @@
+package examples
+
+fn describe(shape: Any) {
+    condition {
+        when shape.kind == "circle" => {
+            print("Circle area:", 3.14159 * shape.radius * shape.radius);
+        }
+        when shape.kind == "rectangle" => {
+            print("Rectangle area:", shape.width * shape.height);
+        }
+        else => {
+            print("Unknown shape type", shape.kind);
+        }
+    }
+}
+
+let circle = { kind: "circle", radius: 5 };
+let rect = { kind: "rectangle", width: 4, height: 6 };
+let mystery = { kind: "triangle" };
+
+describe(circle);
+describe(rect);
+describe(mystery);

--- a/examples/contracts.selene
+++ b/examples/contracts.selene
@@ -1,0 +1,31 @@
+// Demonstrates function contracts and reusable contract declarations.
+
+contract validators {
+    fn withinRange(value: Number, min: Number, max: Number): Boolean {
+        return value >= min && value <= max;
+    }
+}
+
+fn clamp(value: Number, min: Number, max: Number): Number
+    contract {
+        returns(result) => result >= min;
+        returns(result) => result <= max;
+    }
+{
+    if value < min {
+        return min;
+    }
+    if value > max {
+        return max;
+    }
+    return value;
+}
+
+let values = [ -5, 3, 42 ];
+for (let i = 0; i < values.length; i = i + 1) {
+    let original = values[i];
+    let clamped = clamp(original, 0, 10);
+    print("clamp(" + original + ") => " + clamped);
+    let ok = validators.withinRange(clamped, 0, 10);
+    print("within range? => " + ok);
+}

--- a/examples/control.selene
+++ b/examples/control.selene
@@ -1,0 +1,37 @@
+// Demonstrates Selene control flow.
+var total = 0;
+
+for (let i = 0; i < 10; i = i + 1) {
+    if i % 2 == 0 {
+        continue;
+    }
+    if i > 7 {
+        break;
+    }
+    total = total + i;
+}
+
+var countdown = 3;
+while countdown > 0 {
+    print("tick", countdown);
+    countdown = countdown - 1;
+}
+
+fn fib(n: Number): Number {
+    if n <= 1 {
+        return n;
+    }
+    return fib(n - 1) + fib(n - 2);
+}
+
+print("total", total);
+print("fib(6)", fib(6));
+
+var attempts = 0;
+while true {
+    attempts = attempts + 1;
+    if attempts == 3 {
+        print("finished after", attempts, "tries");
+        break;
+    }
+}

--- a/examples/dependency.selene
+++ b/examples/dependency.selene
@@ -1,0 +1,16 @@
+package main;
+
+import math "github.com/selene-lang/richmath";
+
+fn describe(values: Array) {
+    print("values:", values);
+    print("sum:", math.sum(values));
+    print("average:", math.average(values));
+    print("running mean:", math.stats.runningMean(values));
+}
+
+fn main() {
+    describe([2, 4, 6, 8, 10]);
+}
+
+main();

--- a/examples/errors.selene
+++ b/examples/errors.selene
@@ -1,0 +1,29 @@
+package examples
+
+struct Trace(name: String) {
+    fn close() {
+        print("closing", self.name);
+    }
+}
+
+fn open(name: String): Trace {
+    print("opening", name);
+    return Trace(name);
+}
+
+fn risky(flag: Boolean) {
+    if flag {
+        throw "something went wrong";
+    }
+    print("all good");
+}
+
+using scope = open("session.log") {
+    try {
+        risky(true);
+    } catch (err) {
+        print("caught:", err);
+    } finally {
+        print("finally always runs");
+    }
+}

--- a/examples/extensions.selene
+++ b/examples/extensions.selene
@@ -1,0 +1,22 @@
+package examples
+
+ext fn String.reverse(): String {
+    var result = "";
+    var index = this.length - 1;
+    while index >= 0 {
+        result = result + this[index];
+        index -= 1;
+    }
+    return result;
+}
+
+ext fn String.isPalindrome(): Boolean = this == this.reverse();
+
+ext fn Int.squared(): Int = this * this;
+
+let word = "level";
+print(word.reverse());
+print(word.isPalindrome());
+
+let value = 7;
+print(value.squared());

--- a/examples/hello.selene
+++ b/examples/hello.selene
@@ -1,0 +1,10 @@
+// examples/hello.selene
+let greeting: String = "Hello";
+
+fn greet(name: String): String => greeting + ", " + name;
+
+fn main() {
+    print(greet("Selene"));
+}
+
+main();

--- a/examples/interfaces.selene
+++ b/examples/interfaces.selene
@@ -1,0 +1,23 @@
+package examples
+
+interface Speaker {
+    fn speak(name: String): String;
+}
+
+struct Person(name: String) {
+    fn speak(name: String): String => "Hi, I'm " + name + " (" + self.name + ")";
+}
+
+ext fn String.speak(name: String): String => "Echo from \"" + this + "\" to " + name;
+
+fn introduce(someone: Speaker, name: String) {
+    print(someone.speak(name));
+}
+
+let luna = Person("Luna");
+introduce(luna, "Orion");
+
+let word = "Selene";
+if word is Speaker {
+    introduce(word, "Orion");
+}

--- a/examples/math.selene
+++ b/examples/math.selene
@@ -1,0 +1,15 @@
+// Demonstrates Selene arithmetic helpers and reusable functions.
+let pi: Number = 314159 / 100000;
+
+fn circleArea(radius: Number): Number => radius * radius * pi;
+fn circumference(radius: Number): Number => 2 * pi * radius;
+
+fn report(name: String, radius: Number) {
+    let area = circleArea(radius);
+    let edge = circumference(radius);
+    print(name + " => area=" + area + ", circumference=" + edge);
+}
+
+report("small", 2);
+report("medium", 5);
+report("large", 9);

--- a/examples/modules.selene
+++ b/examples/modules.selene
@@ -1,0 +1,15 @@
+// Modules and imports in Selene.
+module math_utils {
+    fn square(n: Number): Number => n * n;
+    let constants = { tau: 6.28318 };
+}
+
+import math_utils.square;
+import math_utils.constants as consts;
+
+fn main() {
+    print("square(5) =", square(5));
+    print("tau ≈", consts.tau);
+}
+
+main();

--- a/examples/options.selene
+++ b/examples/options.selene
@@ -1,0 +1,16 @@
+let profile = {
+    name: "Nova",
+    contact: {
+        email: "nova@example.com",
+        address: null
+    }
+};
+
+let email = profile.contact?.email ?: "unknown@selene.dev";
+print("Email: " + email);
+
+let city = profile.contact?.address?.city ?: "Unknown";
+print("City: " + city);
+
+let safeContact = profile.contact!!;
+print("Forced contact email: " + safeContact.email);

--- a/examples/packages.selene
+++ b/examples/packages.selene
@@ -1,0 +1,29 @@
+package main;
+
+module math_utils {
+    fn increment(n: Number): Number => n + 1;
+    fn triple(n: Number): Number => n * 3;
+}
+
+import utils "math_utils";
+
+fn compute(value: Number): Number {
+    var result = value;
+    result += utils.increment(value);
+    result *= 2;
+    result -= 4;
+    result /= 3;
+    result %= 5;
+    return result;
+}
+
+fn main() {
+    let start = 6;
+    var score = start;
+    score += 2;
+    score *= 3;
+    print("score:", score);
+    print("compute(score):", compute(score));
+}
+
+main();

--- a/examples/patterns.selene
+++ b/examples/patterns.selene
@@ -1,0 +1,18 @@
+let shapes = [
+    { kind: "circle", radius: 2 },
+    { kind: "square", side: 4 },
+    { kind: "triangle", base: 3, height: 4 }
+];
+
+fn describe(shape: Any) {
+    match shape {
+        { kind: "circle", radius: r } => print("Circle with radius " + r);
+        { kind: "square", side: s } => print("Square with side " + s);
+        other => print("Unknown shape kind " + (other.kind ?: "n/a"));
+    }
+}
+
+print("Cataloging shapes:");
+describe(shapes[0]);
+describe(shapes[1]);
+describe(shapes[2]);

--- a/examples/pointers.selene
+++ b/examples/pointers.selene
@@ -1,0 +1,26 @@
+package examples
+
+let counter = 41;
+let handle = &counter;
+
+fn bump(value: Pointer) {
+    *value += 1;
+}
+
+bump(handle);
+print("after bump:", counter);
+
+let alias = handle;
+*alias += 10;
+print("after alias:", counter);
+
+fn swap(a: Pointer, b: Pointer) {
+    let temp = *a;
+    *a = *b;
+    *b = temp;
+}
+
+let first = 5;
+let second = 12;
+swap(&first, &second);
+print("swapped:", first, second);

--- a/examples/recursion.selene
+++ b/examples/recursion.selene
@@ -1,0 +1,11 @@
+fn factorial(n: Number) {
+    match n {
+        0 => 1;
+        1 => 1;
+        value => value * factorial(value - 1);
+    }
+}
+
+print("Factorial results:");
+print("5! = " + factorial(5));
+print("7! = " + factorial(7));

--- a/examples/strings.selene
+++ b/examples/strings.selene
@@ -1,0 +1,27 @@
+package examples
+
+ext fn String.reverse(): String {
+    var result = "";
+    var i = this.length - 1;
+    while i >= 0 {
+        result = result + this[i];
+        i -= 1;
+    }
+    return result;
+}
+
+ext fn String.isPalindrome(): Boolean = this == this.reverse();
+
+let name = "Selene";
+let greeting = "Hello, ${name}!";
+let raw = r"""raw strings keep \${placeholders} untouched""";
+let multi = """over
+multiple
+lines""";
+let precise = f"pi ~= ${3.1415926535:%.2f}";
+
+print(greeting);
+print(raw);
+print(multi);
+print(precise);
+print(f"is ${name} a palindrome? ${name.isPalindrome():upper}");

--- a/examples/types.selene
+++ b/examples/types.selene
@@ -1,0 +1,31 @@
+// User-defined data types in Selene.
+struct Point(x: Number, y: Number) {
+    fn describe(): String {
+        return "Point(" + self.x + ", " + self.y + ")";
+    }
+}
+
+class Greeter(name: String) {
+    fn greet(target: String): String {
+        return self.name + ", " + target;
+    }
+}
+
+enum Option {
+    Some(value: Number);
+    None;
+}
+
+let origin = Point(0, 0);
+let offset = Point(3, 4);
+let greeter = Greeter("Selene");
+let value = Option.Some(41);
+
+print(origin.describe());
+print(offset.describe());
+print(greeter.greet("friend"));
+
+match value {
+    Some(v) => print("value + 1 =", v + 1);
+    None => print("no value");
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module selenelang
+
+go 1.24.3

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -1,0 +1,644 @@
+package ast
+
+import "selenelang/internal/token"
+
+type Node interface {
+	Pos() token.Position
+	End() token.Position
+}
+
+type ProgramItem interface {
+	Node
+	programItemNode()
+}
+
+type Program struct {
+	Items  []ProgramItem
+	Start  token.Position
+	Finish token.Position
+}
+
+func (p *Program) Pos() token.Position { return p.Start }
+func (p *Program) End() token.Position { return p.Finish }
+
+type Statement interface {
+	ProgramItem
+	statementNode()
+}
+
+type Expression interface {
+	Node
+	expressionNode()
+}
+
+type Pattern interface {
+	Node
+	patternNode()
+}
+
+type Identifier struct {
+	Name   string
+	Start  token.Position
+	Finish token.Position
+}
+
+func (i *Identifier) Pos() token.Position { return i.Start }
+func (i *Identifier) End() token.Position { return i.Finish }
+func (i *Identifier) expressionNode()     {}
+func (i *Identifier) patternNode()        {}
+
+// Literals
+
+type NumberLiteral struct {
+	Value  string
+	Start  token.Position
+	Finish token.Position
+}
+
+func (n *NumberLiteral) Pos() token.Position { return n.Start }
+func (n *NumberLiteral) End() token.Position { return n.Finish }
+func (n *NumberLiteral) expressionNode()     {}
+func (n *NumberLiteral) patternNode()        {}
+
+type StringLiteral struct {
+	Value  string
+	Raw    bool
+	Format bool
+	Start  token.Position
+	Finish token.Position
+}
+
+func (s *StringLiteral) Pos() token.Position { return s.Start }
+func (s *StringLiteral) End() token.Position { return s.Finish }
+func (s *StringLiteral) expressionNode()     {}
+func (s *StringLiteral) patternNode()        {}
+
+type BooleanLiteral struct {
+	Value  bool
+	Start  token.Position
+	Finish token.Position
+}
+
+func (b *BooleanLiteral) Pos() token.Position { return b.Start }
+func (b *BooleanLiteral) End() token.Position { return b.Finish }
+func (b *BooleanLiteral) expressionNode()     {}
+func (b *BooleanLiteral) patternNode()        {}
+
+type NullLiteral struct {
+	Start  token.Position
+	Finish token.Position
+}
+
+func (n *NullLiteral) Pos() token.Position { return n.Start }
+func (n *NullLiteral) End() token.Position { return n.Finish }
+func (n *NullLiteral) expressionNode()     {}
+func (n *NullLiteral) patternNode()        {}
+
+// Composite literals
+
+type ArrayLiteral struct {
+	Elements []Expression
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (a *ArrayLiteral) Pos() token.Position { return a.Start }
+func (a *ArrayLiteral) End() token.Position { return a.Finish }
+func (a *ArrayLiteral) expressionNode()     {}
+
+type ObjectPair struct {
+	Key             string
+	KeyIsIdentifier bool
+	Value           Expression
+}
+
+type ObjectLiteral struct {
+	Pairs  []ObjectPair
+	Start  token.Position
+	Finish token.Position
+}
+
+func (o *ObjectLiteral) Pos() token.Position { return o.Start }
+func (o *ObjectLiteral) End() token.Position { return o.Finish }
+func (o *ObjectLiteral) expressionNode()     {}
+
+// Expressions
+
+type AwaitExpression struct {
+	Expression Expression
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (a *AwaitExpression) Pos() token.Position { return a.Start }
+func (a *AwaitExpression) End() token.Position { return a.Finish }
+func (a *AwaitExpression) expressionNode()     {}
+
+type PrefixExpression struct {
+	Operator string
+	Right    Expression
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (p *PrefixExpression) Pos() token.Position { return p.Start }
+func (p *PrefixExpression) End() token.Position { return p.Finish }
+func (p *PrefixExpression) expressionNode()     {}
+
+type InfixExpression struct {
+	Left     Expression
+	Operator string
+	Right    Expression
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (i *InfixExpression) Pos() token.Position { return i.Start }
+func (i *InfixExpression) End() token.Position { return i.Finish }
+func (i *InfixExpression) expressionNode()     {}
+
+type AssignmentExpression struct {
+	Target   Expression
+	Value    Expression
+	Operator token.Type
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (a *AssignmentExpression) Pos() token.Position { return a.Start }
+func (a *AssignmentExpression) End() token.Position { return a.Finish }
+func (a *AssignmentExpression) expressionNode()     {}
+
+type ElvisExpression struct {
+	Left   Expression
+	Right  Expression
+	Start  token.Position
+	Finish token.Position
+}
+
+func (e *ElvisExpression) Pos() token.Position { return e.Start }
+func (e *ElvisExpression) End() token.Position { return e.Finish }
+func (e *ElvisExpression) expressionNode()     {}
+
+type CallExpression struct {
+	Callee    Expression
+	Arguments []Expression
+	Start     token.Position
+	Finish    token.Position
+}
+
+func (c *CallExpression) Pos() token.Position { return c.Start }
+func (c *CallExpression) End() token.Position { return c.Finish }
+func (c *CallExpression) expressionNode()     {}
+
+type IndexExpression struct {
+	Collection Expression
+	Index      Expression
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (i *IndexExpression) Pos() token.Position { return i.Start }
+func (i *IndexExpression) End() token.Position { return i.Finish }
+func (i *IndexExpression) expressionNode()     {}
+
+type MemberExpression struct {
+	Object   Expression
+	Property string
+	Optional bool
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (m *MemberExpression) Pos() token.Position { return m.Start }
+func (m *MemberExpression) End() token.Position { return m.Finish }
+func (m *MemberExpression) expressionNode()     {}
+
+type NonNullAssertion struct {
+	Expression Expression
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (n *NonNullAssertion) Pos() token.Position { return n.Start }
+func (n *NonNullAssertion) End() token.Position { return n.Finish }
+func (n *NonNullAssertion) expressionNode()     {}
+
+// Statements
+
+type BlockStatement struct {
+	Statements []Statement
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (b *BlockStatement) Pos() token.Position { return b.Start }
+func (b *BlockStatement) End() token.Position { return b.Finish }
+func (b *BlockStatement) statementNode()      {}
+func (b *BlockStatement) programItemNode()    {}
+
+type ExpressionStatement struct {
+	Expression Expression
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (e *ExpressionStatement) Pos() token.Position { return e.Start }
+func (e *ExpressionStatement) End() token.Position { return e.Finish }
+func (e *ExpressionStatement) statementNode()      {}
+func (e *ExpressionStatement) programItemNode()    {}
+
+type IfStatement struct {
+	Condition   Expression
+	Consequence Statement
+	Alternative Statement
+	Start       token.Position
+	Finish      token.Position
+}
+
+func (i *IfStatement) Pos() token.Position { return i.Start }
+func (i *IfStatement) End() token.Position { return i.Finish }
+func (i *IfStatement) statementNode()      {}
+func (i *IfStatement) programItemNode()    {}
+
+type WhileStatement struct {
+	Condition Expression
+	Body      Statement
+	Start     token.Position
+	Finish    token.Position
+}
+
+func (w *WhileStatement) Pos() token.Position { return w.Start }
+func (w *WhileStatement) End() token.Position { return w.Finish }
+func (w *WhileStatement) statementNode()      {}
+func (w *WhileStatement) programItemNode()    {}
+
+type ForStatement struct {
+	Init      Statement
+	Condition Expression
+	Post      Expression
+	Body      Statement
+	Start     token.Position
+	Finish    token.Position
+}
+
+func (f *ForStatement) Pos() token.Position { return f.Start }
+func (f *ForStatement) End() token.Position { return f.Finish }
+func (f *ForStatement) statementNode()      {}
+func (f *ForStatement) programItemNode()    {}
+
+type ReturnStatement struct {
+	Value  Expression
+	Start  token.Position
+	Finish token.Position
+}
+
+func (r *ReturnStatement) Pos() token.Position { return r.Start }
+func (r *ReturnStatement) End() token.Position { return r.Finish }
+func (r *ReturnStatement) statementNode()      {}
+func (r *ReturnStatement) programItemNode()    {}
+
+type BreakStatement struct {
+	Start  token.Position
+	Finish token.Position
+}
+
+func (b *BreakStatement) Pos() token.Position { return b.Start }
+func (b *BreakStatement) End() token.Position { return b.Finish }
+func (b *BreakStatement) statementNode()      {}
+func (b *BreakStatement) programItemNode()    {}
+
+type ContinueStatement struct {
+	Start  token.Position
+	Finish token.Position
+}
+
+func (c *ContinueStatement) Pos() token.Position { return c.Start }
+func (c *ContinueStatement) End() token.Position { return c.Finish }
+func (c *ContinueStatement) statementNode()      {}
+func (c *ContinueStatement) programItemNode()    {}
+
+type ThrowStatement struct {
+	Value  Expression
+	Start  token.Position
+	Finish token.Position
+}
+
+func (t *ThrowStatement) Pos() token.Position { return t.Start }
+func (t *ThrowStatement) End() token.Position { return t.Finish }
+func (t *ThrowStatement) statementNode()      {}
+func (t *ThrowStatement) programItemNode()    {}
+
+type UsingStatement struct {
+	Name   *Identifier
+	Value  Expression
+	Body   *BlockStatement
+	Start  token.Position
+	Finish token.Position
+}
+
+func (u *UsingStatement) Pos() token.Position { return u.Start }
+func (u *UsingStatement) End() token.Position { return u.Finish }
+func (u *UsingStatement) statementNode()      {}
+func (u *UsingStatement) programItemNode()    {}
+
+type TryStatement struct {
+	Body    *BlockStatement
+	Catch   *CatchClause
+	Finally *BlockStatement
+	Start   token.Position
+	Finish  token.Position
+}
+
+func (t *TryStatement) Pos() token.Position { return t.Start }
+func (t *TryStatement) End() token.Position { return t.Finish }
+func (t *TryStatement) statementNode()      {}
+func (t *TryStatement) programItemNode()    {}
+
+type CatchClause struct {
+	Identifier *Identifier
+	Body       *BlockStatement
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (c *CatchClause) Pos() token.Position { return c.Start }
+func (c *CatchClause) End() token.Position { return c.Finish }
+
+type ConditionClause struct {
+	Test   Expression
+	Body   Statement
+	Start  token.Position
+	Finish token.Position
+}
+
+func (c *ConditionClause) Pos() token.Position { return c.Start }
+func (c *ConditionClause) End() token.Position { return c.Finish }
+
+type ConditionStatement struct {
+	Clauses []ConditionClause
+	Else    Statement
+	Start   token.Position
+	Finish  token.Position
+}
+
+func (c *ConditionStatement) Pos() token.Position { return c.Start }
+func (c *ConditionStatement) End() token.Position { return c.Finish }
+func (c *ConditionStatement) statementNode()      {}
+func (c *ConditionStatement) programItemNode()    {}
+
+type VariableDeclaration struct {
+	Mutable bool
+	Name    *Identifier
+	Type    *TypeAnnotation
+	Value   Expression
+	Start   token.Position
+	Finish  token.Position
+}
+
+func (v *VariableDeclaration) Pos() token.Position { return v.Start }
+func (v *VariableDeclaration) End() token.Position { return v.Finish }
+func (v *VariableDeclaration) statementNode()      {}
+func (v *VariableDeclaration) programItemNode()    {}
+
+type Parameter struct {
+	Name *Identifier
+	Type *TypeAnnotation
+}
+
+type TypeAnnotation struct {
+	Name     *Identifier
+	TypeArgs []*TypeAnnotation
+	Nullable bool
+	Start    token.Position
+	Finish   token.Position
+}
+
+func (t *TypeAnnotation) Pos() token.Position { return t.Start }
+func (t *TypeAnnotation) End() token.Position { return t.Finish }
+
+// Functions and contracts
+
+type FunctionDeclaration struct {
+	Name        *Identifier
+	Receiver    *TypeAnnotation
+	TypeParams  []*Identifier
+	Params      []Parameter
+	ReturnType  *TypeAnnotation
+	Async       bool
+	Contract    *ContractBlock
+	Body        *BlockStatement
+	BodyExpr    Expression
+	IsExprBody  bool
+	IsExtension bool
+	Start       token.Position
+	Finish      token.Position
+}
+
+func (f *FunctionDeclaration) Pos() token.Position { return f.Start }
+func (f *FunctionDeclaration) End() token.Position { return f.Finish }
+func (f *FunctionDeclaration) statementNode()      {}
+func (f *FunctionDeclaration) programItemNode()    {}
+
+type ContractBlock struct {
+	Clauses []ContractClause
+	Start   token.Position
+	Finish  token.Position
+}
+
+func (c *ContractBlock) Pos() token.Position { return c.Start }
+func (c *ContractBlock) End() token.Position { return c.Finish }
+
+type ContractClause struct {
+	Guard     Expression
+	Condition Expression
+	Start     token.Position
+	Finish    token.Position
+}
+
+func (c *ContractClause) Pos() token.Position { return c.Start }
+func (c *ContractClause) End() token.Position { return c.Finish }
+
+type ClassDeclaration struct {
+	Name       *Identifier
+	Params     []Parameter
+	SuperClass *Identifier
+	Body       *BlockStatement
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (c *ClassDeclaration) Pos() token.Position { return c.Start }
+func (c *ClassDeclaration) End() token.Position { return c.Finish }
+func (c *ClassDeclaration) statementNode()      {}
+func (c *ClassDeclaration) programItemNode()    {}
+
+type InterfaceDeclaration struct {
+	Name    *Identifier
+	Methods []InterfaceMethod
+	Start   token.Position
+	Finish  token.Position
+}
+
+func (i *InterfaceDeclaration) Pos() token.Position { return i.Start }
+func (i *InterfaceDeclaration) End() token.Position { return i.Finish }
+func (i *InterfaceDeclaration) statementNode()      {}
+func (i *InterfaceDeclaration) programItemNode()    {}
+
+type InterfaceMethod struct {
+	Name       *Identifier
+	Params     []Parameter
+	ReturnType *TypeAnnotation
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (m *InterfaceMethod) Pos() token.Position { return m.Start }
+func (m *InterfaceMethod) End() token.Position { return m.Finish }
+
+type StructDeclaration struct {
+	Name   *Identifier
+	Params []Parameter
+	Body   *BlockStatement
+	Start  token.Position
+	Finish token.Position
+}
+
+func (s *StructDeclaration) Pos() token.Position { return s.Start }
+func (s *StructDeclaration) End() token.Position { return s.Finish }
+func (s *StructDeclaration) statementNode()      {}
+func (s *StructDeclaration) programItemNode()    {}
+
+type EnumDeclaration struct {
+	Name       *Identifier
+	TypeParams []*Identifier
+	Cases      []EnumCase
+	Start      token.Position
+	Finish     token.Position
+}
+
+func (e *EnumDeclaration) Pos() token.Position { return e.Start }
+func (e *EnumDeclaration) End() token.Position { return e.Finish }
+func (e *EnumDeclaration) statementNode()      {}
+func (e *EnumDeclaration) programItemNode()    {}
+
+type EnumCase struct {
+	Name   *Identifier
+	Params []Parameter
+	Start  token.Position
+	Finish token.Position
+}
+
+func (e *EnumCase) Pos() token.Position { return e.Start }
+func (e *EnumCase) End() token.Position { return e.Finish }
+
+type ContractDeclaration struct {
+	Name   *Identifier
+	Body   *BlockStatement
+	Start  token.Position
+	Finish token.Position
+}
+
+func (c *ContractDeclaration) Pos() token.Position { return c.Start }
+func (c *ContractDeclaration) End() token.Position { return c.Finish }
+func (c *ContractDeclaration) statementNode()      {}
+func (c *ContractDeclaration) programItemNode()    {}
+
+type ImportDeclaration struct {
+	Path        []*Identifier
+	PathLiteral string
+	Alias       *Identifier
+	Start       token.Position
+	Finish      token.Position
+}
+
+func (i *ImportDeclaration) Pos() token.Position { return i.Start }
+func (i *ImportDeclaration) End() token.Position { return i.Finish }
+func (i *ImportDeclaration) statementNode()      {}
+func (i *ImportDeclaration) programItemNode()    {}
+
+type PackageDeclaration struct {
+	Name   *Identifier
+	Start  token.Position
+	Finish token.Position
+}
+
+func (p *PackageDeclaration) Pos() token.Position { return p.Start }
+func (p *PackageDeclaration) End() token.Position { return p.Finish }
+func (p *PackageDeclaration) programItemNode()    {}
+
+type ModuleDeclaration struct {
+	Name   *Identifier
+	Body   *BlockStatement
+	Start  token.Position
+	Finish token.Position
+}
+
+func (m *ModuleDeclaration) Pos() token.Position { return m.Start }
+func (m *ModuleDeclaration) End() token.Position { return m.Finish }
+func (m *ModuleDeclaration) programItemNode()    {}
+
+type MatchStatement struct {
+	Value  Expression
+	Cases  []MatchCase
+	Start  token.Position
+	Finish token.Position
+}
+
+func (m *MatchStatement) Pos() token.Position { return m.Start }
+func (m *MatchStatement) End() token.Position { return m.Finish }
+func (m *MatchStatement) statementNode()      {}
+func (m *MatchStatement) programItemNode()    {}
+
+type MatchCase struct {
+	Pattern Pattern
+	Body    Statement
+	Start   token.Position
+	Finish  token.Position
+}
+
+func (m *MatchCase) Pos() token.Position { return m.Start }
+func (m *MatchCase) End() token.Position { return m.Finish }
+
+type PatternPair struct {
+	Key             string
+	KeyIsIdentifier bool
+	Value           Pattern
+}
+
+type ObjectPattern struct {
+	Pairs  []PatternPair
+	Start  token.Position
+	Finish token.Position
+}
+
+func (o *ObjectPattern) Pos() token.Position { return o.Start }
+func (o *ObjectPattern) End() token.Position { return o.Finish }
+func (o *ObjectPattern) patternNode()        {}
+
+type StructPattern struct {
+	Name   *Identifier
+	Fields []Pattern
+	Start  token.Position
+	Finish token.Position
+}
+
+func (s *StructPattern) Pos() token.Position { return s.Start }
+func (s *StructPattern) End() token.Position { return s.Finish }
+func (s *StructPattern) patternNode()        {}
+
+type IdentifierPattern struct {
+	Identifier *Identifier
+}
+
+func (i *IdentifierPattern) Pos() token.Position { return i.Identifier.Pos() }
+func (i *IdentifierPattern) End() token.Position { return i.Identifier.End() }
+func (i *IdentifierPattern) patternNode()        {}
+
+type LiteralPattern struct {
+	Value Expression
+}
+
+func (l *LiteralPattern) Pos() token.Position { return l.Value.Pos() }
+func (l *LiteralPattern) End() token.Position { return l.Value.End() }
+func (l *LiteralPattern) patternNode()        {}

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -1,0 +1,514 @@
+package lexer
+
+import (
+	"strings"
+
+	"selenelang/internal/token"
+)
+
+type Lexer struct {
+	input        []rune
+	position     int
+	readPosition int
+	ch           rune
+	line         int
+	column       int
+}
+
+func New(input string) *Lexer {
+	l := &Lexer{
+		input: []rune(input),
+		line:  1,
+	}
+	l.readRune()
+	return l
+}
+
+func (l *Lexer) NextToken() token.Token {
+	l.skipWhitespaceAndComments()
+
+	startOffset := l.position
+	startLine := l.line
+	startColumn := l.column
+
+	tok := token.Token{
+		Pos: token.Position{Offset: startOffset, Line: startLine, Column: startColumn},
+	}
+
+	switch l.ch {
+	case 0:
+		tok.Type = token.EOF
+		tok.Literal = ""
+		tok.End = tok.Pos
+		return tok
+	case '+':
+		if l.peekRune() == '=' {
+			tok.Type = token.PLUS_ASSIGN
+			tok.Literal = "+="
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.PLUS
+			tok.Literal = "+"
+			l.readRune()
+		}
+	case '-':
+		if l.peekRune() == '=' {
+			tok.Type = token.MINUS_ASSIGN
+			tok.Literal = "-="
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.MINUS
+			tok.Literal = "-"
+			l.readRune()
+		}
+	case '*':
+		if l.peekRune() == '=' {
+			tok.Type = token.STAR_ASSIGN
+			tok.Literal = "*="
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.ASTERISK
+			tok.Literal = "*"
+			l.readRune()
+		}
+	case '%':
+		if l.peekRune() == '=' {
+			tok.Type = token.PERCENT_ASSIGN
+			tok.Literal = "%="
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.PERCENT
+			tok.Literal = "%"
+			l.readRune()
+		}
+	case ',':
+		tok.Type = token.COMMA
+		tok.Literal = ","
+		l.readRune()
+	case ';':
+		tok.Type = token.SEMICOLON
+		tok.Literal = ";"
+		l.readRune()
+	case '(':
+		tok.Type = token.LPAREN
+		tok.Literal = "("
+		l.readRune()
+	case ')':
+		tok.Type = token.RPAREN
+		tok.Literal = ")"
+		l.readRune()
+	case '{':
+		tok.Type = token.LBRACE
+		tok.Literal = "{"
+		l.readRune()
+	case '}':
+		tok.Type = token.RBRACE
+		tok.Literal = "}"
+		l.readRune()
+	case '[':
+		tok.Type = token.LBRACKET
+		tok.Literal = "["
+		l.readRune()
+	case ']':
+		tok.Type = token.RBRACKET
+		tok.Literal = "]"
+		l.readRune()
+	case '.':
+		tok.Type = token.DOT
+		tok.Literal = "."
+		l.readRune()
+	case ':':
+		tok.Type = token.COLON
+		tok.Literal = ":"
+		l.readRune()
+	case '?':
+		switch l.peekRune() {
+		case ':':
+			tok.Type = token.ELVIS
+			tok.Literal = "?:"
+			l.readRune()
+			l.readRune()
+		case '.':
+			tok.Type = token.SAFE_DOT
+			tok.Literal = "?."
+			l.readRune()
+			l.readRune()
+		default:
+			tok.Type = token.QUESTION
+			tok.Literal = "?"
+			l.readRune()
+		}
+	case '!':
+		switch l.peekRune() {
+		case '=':
+			tok.Type = token.NOT_EQ
+			tok.Literal = "!="
+			l.readRune()
+			l.readRune()
+		case '!':
+			tok.Type = token.NON_NULL
+			tok.Literal = "!!"
+			l.readRune()
+			l.readRune()
+		default:
+			if l.peekWord("is") {
+				tok.Type = token.NOT_IS
+				tok.Literal = "!is"
+				l.readRune()
+				l.readRune() // consume 'i'
+				l.readRune() // consume 's'
+			} else {
+				tok.Type = token.BANG
+				tok.Literal = "!"
+				l.readRune()
+			}
+		}
+	case '=':
+		switch l.peekRune() {
+		case '=':
+			tok.Type = token.EQ
+			tok.Literal = "=="
+			l.readRune()
+			l.readRune()
+		case '>':
+			tok.Type = token.ARROW
+			tok.Literal = "=>"
+			l.readRune()
+			l.readRune()
+		default:
+			tok.Type = token.ASSIGN
+			tok.Literal = "="
+			l.readRune()
+		}
+	case '<':
+		if l.peekRune() == '=' {
+			tok.Type = token.LTE
+			tok.Literal = "<="
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.LT
+			tok.Literal = "<"
+			l.readRune()
+		}
+	case '>':
+		if l.peekRune() == '=' {
+			tok.Type = token.GTE
+			tok.Literal = ">="
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.GT
+			tok.Literal = ">"
+			l.readRune()
+		}
+	case '&':
+		if l.peekRune() == '&' {
+			tok.Type = token.AND
+			tok.Literal = "&&"
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.AMPERSAND
+			tok.Literal = "&"
+			l.readRune()
+		}
+	case '|':
+		if l.peekRune() == '|' {
+			tok.Type = token.OR
+			tok.Literal = "||"
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.ILLEGAL
+			tok.Literal = string(l.ch)
+			l.readRune()
+		}
+	case '/':
+		if l.peekRune() == '=' {
+			tok.Type = token.SLASH_ASSIGN
+			tok.Literal = "/="
+			l.readRune()
+			l.readRune()
+		} else {
+			tok.Type = token.SLASH
+			tok.Literal = "/"
+			l.readRune()
+		}
+	case '"':
+		if l.peekRune() == '"' && l.peekRuneN(2) == '"' {
+			lit := l.readTripleQuotedString()
+			tok.Type = token.STRING
+			tok.Literal = lit
+		} else {
+			lit := l.readString()
+			tok.Type = token.STRING
+			tok.Literal = lit
+		}
+	case '`':
+		lit := l.readRawString('`')
+		tok.Type = token.RAWSTRING
+		tok.Literal = lit
+	default:
+		if isLetter(l.ch) {
+			literal := l.readIdentifier()
+			switch {
+			case literal == "f" && l.ch == '"':
+				var lit string
+				if l.peekRune() == '"' && l.peekRuneN(2) == '"' {
+					lit = l.readTripleQuotedString()
+				} else {
+					lit = l.readString()
+				}
+				tok.Type = token.FORMATSTRING
+				tok.Literal = lit
+			case literal == "r" && l.ch == '"':
+				var lit string
+				if l.peekRune() == '"' && l.peekRuneN(2) == '"' {
+					lit = l.readRawTripleQuotedString()
+				} else {
+					lit = l.readRawString('"')
+				}
+				tok.Type = token.RAWSTRING
+				tok.Literal = lit
+			default:
+				tok.Type = token.LookupIdent(literal)
+				tok.Literal = literal
+			}
+		} else if isDigit(l.ch) {
+			literal := l.readNumber()
+			tok.Type = token.NUMBER
+			tok.Literal = literal
+		} else {
+			tok.Type = token.ILLEGAL
+			tok.Literal = string(l.ch)
+			l.readRune()
+		}
+	}
+
+	tok.End = token.Position{Offset: l.position, Line: l.line, Column: l.column}
+	return tok
+}
+
+func (l *Lexer) readRune() {
+	if l.readPosition >= len(l.input) {
+		l.position = len(l.input)
+		l.ch = 0
+		return
+	}
+	l.position = l.readPosition
+	l.ch = l.input[l.readPosition]
+	l.readPosition++
+	if l.ch == '\n' {
+		l.line++
+		l.column = 0
+	} else {
+		l.column++
+	}
+}
+
+func (l *Lexer) peekRune() rune {
+	if l.readPosition >= len(l.input) {
+		return 0
+	}
+	return l.input[l.readPosition]
+}
+
+func (l *Lexer) peekRuneN(n int) rune {
+	index := l.readPosition + n - 1
+	if index < 0 || index >= len(l.input) {
+		return 0
+	}
+	return l.input[index]
+}
+
+func (l *Lexer) peekWord(word string) bool {
+	if len(word) == 0 {
+		return false
+	}
+	if l.peekRune() != rune(word[0]) {
+		return false
+	}
+	if l.readPosition+len(word) > len(l.input) {
+		return false
+	}
+	for i, r := range word {
+		if l.readPosition+i >= len(l.input) {
+			return false
+		}
+		if l.input[l.readPosition+i] != r {
+			return false
+		}
+	}
+	nextIndex := l.readPosition + len(word)
+	if nextIndex < len(l.input) {
+		next := l.input[nextIndex]
+		if isLetter(next) || isDigit(next) || next == '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func (l *Lexer) readIdentifier() string {
+	start := l.position
+	for isLetter(l.ch) || isDigit(l.ch) || l.ch == '_' {
+		l.readRune()
+	}
+	return string(l.input[start:l.position])
+}
+
+func (l *Lexer) readNumber() string {
+	start := l.position
+	for isDigit(l.ch) {
+		l.readRune()
+	}
+	if l.ch == '.' {
+		dotPos := l.position
+		l.readRune()
+		if isDigit(l.ch) {
+			for isDigit(l.ch) {
+				l.readRune()
+			}
+		} else {
+			l.position = dotPos
+			l.readPosition = dotPos
+			l.ch = '.'
+		}
+	}
+	return string(l.input[start:l.position])
+}
+
+func (l *Lexer) readString() string {
+	l.readRune() // consume opening quote
+	start := l.position
+	for l.ch != '"' && l.ch != 0 {
+		if l.ch == '\\' {
+			l.readRune()
+		}
+		l.readRune()
+	}
+	literal := string(l.input[start:l.position])
+	if l.ch == '"' {
+		l.readRune() // consume closing quote
+	}
+	return literal
+}
+
+func (l *Lexer) readTripleQuotedString() string {
+	// consume opening """
+	l.readRune()
+	l.readRune()
+	l.readRune()
+	start := l.position
+	for {
+		if l.ch == 0 {
+			return string(l.input[start:l.position])
+		}
+		if l.ch == '\\' {
+			l.readRune()
+			if l.ch == 0 {
+				break
+			}
+			l.readRune()
+			continue
+		}
+		if l.ch == '"' && l.peekRune() == '"' && l.peekRuneN(2) == '"' {
+			literal := string(l.input[start:l.position])
+			l.readRune()
+			l.readRune()
+			l.readRune()
+			return literal
+		}
+		l.readRune()
+	}
+	return string(l.input[start:l.position])
+}
+
+func (l *Lexer) readRawTripleQuotedString() string {
+	l.readRune()
+	l.readRune()
+	l.readRune()
+	start := l.position
+	for {
+		if l.ch == 0 {
+			return string(l.input[start:l.position])
+		}
+		if l.ch == '"' && l.peekRune() == '"' && l.peekRuneN(2) == '"' {
+			literal := string(l.input[start:l.position])
+			l.readRune()
+			l.readRune()
+			l.readRune()
+			return literal
+		}
+		l.readRune()
+	}
+}
+
+func (l *Lexer) readRawString(delim rune) string {
+	l.readRune() // consume opening delimiter
+	start := l.position
+	for l.ch != delim && l.ch != 0 {
+		l.readRune()
+	}
+	literal := string(l.input[start:l.position])
+	if l.ch == delim {
+		l.readRune() // consume closing delimiter
+	}
+	return literal
+}
+
+func (l *Lexer) skipWhitespaceAndComments() {
+	for {
+		for l.ch == ' ' || l.ch == '\t' || l.ch == '\n' || l.ch == '\r' {
+			l.readRune()
+		}
+		if l.ch == '/' {
+			switch l.peekRune() {
+			case '/':
+				l.consumeLineComment()
+				continue
+			case '*':
+				l.consumeBlockComment()
+				continue
+			}
+		}
+		break
+	}
+}
+
+func (l *Lexer) consumeLineComment() {
+	l.readRune() // consume first '/'
+	l.readRune() // consume second '/'
+	for l.ch != '\n' && l.ch != 0 {
+		l.readRune()
+	}
+}
+
+func (l *Lexer) consumeBlockComment() {
+	l.readRune() // consume first '/'
+	l.readRune() // consume '*'
+	for {
+		if l.ch == 0 {
+			return
+		}
+		if l.ch == '*' && l.peekRune() == '/' {
+			l.readRune()
+			l.readRune()
+			return
+		}
+		l.readRune()
+	}
+}
+
+func isLetter(ch rune) bool {
+	return ch == '_' || strings.ContainsRune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", ch)
+}
+
+func isDigit(ch rune) bool {
+	return ch >= '0' && ch <= '9'
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,0 +1,1524 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+
+	"selenelang/internal/ast"
+	"selenelang/internal/lexer"
+	"selenelang/internal/token"
+)
+
+type (
+	prefixParseFn func() ast.Expression
+	infixParseFn  func(ast.Expression) ast.Expression
+)
+
+type Parser struct {
+	l *lexer.Lexer
+
+	curToken  token.Token
+	peekToken token.Token
+
+	errors []string
+
+	prefixParseFns map[token.Type]prefixParseFn
+	infixParseFns  map[token.Type]infixParseFn
+}
+
+const (
+	_ int = iota
+	LOWEST
+	ASSIGNMENT
+	ELVIS
+	OR
+	AND
+	EQUALITY
+	COMPARISON
+	SUM
+	PRODUCT
+	PREFIX
+	CALL
+)
+
+var precedences = map[token.Type]int{
+	token.ASSIGN:         ASSIGNMENT,
+	token.PLUS_ASSIGN:    ASSIGNMENT,
+	token.MINUS_ASSIGN:   ASSIGNMENT,
+	token.STAR_ASSIGN:    ASSIGNMENT,
+	token.SLASH_ASSIGN:   ASSIGNMENT,
+	token.PERCENT_ASSIGN: ASSIGNMENT,
+	token.ELVIS:          ELVIS,
+	token.OR:             OR,
+	token.AND:            AND,
+	token.EQ:             EQUALITY,
+	token.NOT_EQ:         EQUALITY,
+	token.LT:             COMPARISON,
+	token.LTE:            COMPARISON,
+	token.GT:             COMPARISON,
+	token.GTE:            COMPARISON,
+	token.IS:             COMPARISON,
+	token.NOT_IS:         COMPARISON,
+	token.PLUS:           SUM,
+	token.MINUS:          SUM,
+	token.ASTERISK:       PRODUCT,
+	token.SLASH:          PRODUCT,
+	token.PERCENT:        PRODUCT,
+	token.LPAREN:         CALL,
+	token.LBRACKET:       CALL,
+	token.DOT:            CALL,
+	token.SAFE_DOT:       CALL,
+	token.NON_NULL:       CALL,
+}
+
+func New(l *lexer.Lexer) *Parser {
+	p := &Parser{
+		l:              l,
+		prefixParseFns: make(map[token.Type]prefixParseFn),
+		infixParseFns:  make(map[token.Type]infixParseFn),
+	}
+
+	// Read two tokens so cur and peek are set
+	p.nextToken()
+	p.nextToken()
+
+	p.registerPrefix(token.IDENT, p.parseIdentifier)
+	p.registerPrefix(token.NUMBER, p.parseNumberLiteral)
+	p.registerPrefix(token.STRING, p.parseStringLiteral)
+	p.registerPrefix(token.FORMATSTRING, p.parseStringLiteral)
+	p.registerPrefix(token.RAWSTRING, p.parseStringLiteral)
+	p.registerPrefix(token.TRUE, p.parseBooleanLiteral)
+	p.registerPrefix(token.FALSE, p.parseBooleanLiteral)
+	p.registerPrefix(token.NULL, p.parseNullLiteral)
+	p.registerPrefix(token.MINUS, p.parsePrefixExpression)
+	p.registerPrefix(token.BANG, p.parsePrefixExpression)
+	p.registerPrefix(token.AMPERSAND, p.parsePrefixExpression)
+	p.registerPrefix(token.ASTERISK, p.parsePrefixExpression)
+	p.registerPrefix(token.LPAREN, p.parseGroupedExpression)
+	p.registerPrefix(token.LBRACKET, p.parseArrayLiteral)
+	p.registerPrefix(token.LBRACE, p.parseObjectLiteral)
+	p.registerPrefix(token.AWAIT, p.parseAwaitExpression)
+
+	p.registerInfix(token.PLUS, p.parseInfixExpression)
+	p.registerInfix(token.MINUS, p.parseInfixExpression)
+	p.registerInfix(token.ASTERISK, p.parseInfixExpression)
+	p.registerInfix(token.SLASH, p.parseInfixExpression)
+	p.registerInfix(token.PERCENT, p.parseInfixExpression)
+	p.registerInfix(token.EQ, p.parseInfixExpression)
+	p.registerInfix(token.NOT_EQ, p.parseInfixExpression)
+	p.registerInfix(token.LT, p.parseInfixExpression)
+	p.registerInfix(token.LTE, p.parseInfixExpression)
+	p.registerInfix(token.GT, p.parseInfixExpression)
+	p.registerInfix(token.GTE, p.parseInfixExpression)
+	p.registerInfix(token.OR, p.parseInfixExpression)
+	p.registerInfix(token.AND, p.parseInfixExpression)
+	p.registerInfix(token.IS, p.parseInfixExpression)
+	p.registerInfix(token.NOT_IS, p.parseInfixExpression)
+	p.registerInfix(token.ELVIS, p.parseElvisExpression)
+	p.registerInfix(token.ASSIGN, p.parseAssignmentExpression)
+	p.registerInfix(token.PLUS_ASSIGN, p.parseAssignmentExpression)
+	p.registerInfix(token.MINUS_ASSIGN, p.parseAssignmentExpression)
+	p.registerInfix(token.STAR_ASSIGN, p.parseAssignmentExpression)
+	p.registerInfix(token.SLASH_ASSIGN, p.parseAssignmentExpression)
+	p.registerInfix(token.PERCENT_ASSIGN, p.parseAssignmentExpression)
+	p.registerInfix(token.LPAREN, p.parseCallExpression)
+	p.registerInfix(token.LBRACKET, p.parseIndexExpression)
+	p.registerInfix(token.DOT, p.parseMemberExpression)
+	p.registerInfix(token.SAFE_DOT, p.parseMemberExpression)
+	p.registerInfix(token.NON_NULL, p.parseNonNullAssertion)
+
+	return p
+}
+
+func (p *Parser) Errors() []string {
+	return p.errors
+}
+
+func (p *Parser) nextToken() {
+	p.curToken = p.peekToken
+	p.peekToken = p.l.NextToken()
+}
+
+func (p *Parser) registerPrefix(t token.Type, fn prefixParseFn) {
+	p.prefixParseFns[t] = fn
+}
+
+func (p *Parser) registerInfix(t token.Type, fn infixParseFn) {
+	p.infixParseFns[t] = fn
+}
+
+func (p *Parser) ParseProgram() *ast.Program {
+	program := &ast.Program{}
+	if p.curToken.Type != token.EOF {
+		program.Start = p.curToken.Pos
+	}
+
+	for p.curToken.Type != token.EOF {
+		var item ast.ProgramItem
+		switch p.curToken.Type {
+		case token.PACKAGE:
+			item = p.parsePackageDeclaration()
+		case token.MODULE:
+			item = p.parseModuleDeclaration()
+		default:
+			stmt := p.parseStatement()
+			if stmt != nil {
+				item = stmt
+			}
+		}
+		if item != nil {
+			program.Items = append(program.Items, item)
+		}
+		p.nextToken()
+	}
+
+	program.Finish = p.curToken.Pos
+	return program
+}
+
+func (p *Parser) parseStatement() ast.Statement {
+	switch p.curToken.Type {
+	case token.LET, token.VAR:
+		return p.parseVariableDeclaration()
+	case token.FN:
+		return p.parseFunctionDeclaration()
+	case token.CLASS:
+		return p.parseClassDeclaration()
+	case token.STRUCT:
+		return p.parseStructDeclaration()
+	case token.ENUM:
+		return p.parseEnumDeclaration()
+	case token.CONTRACT:
+		return p.parseContractDeclaration()
+	case token.INTERFACE:
+		return p.parseInterfaceDeclaration()
+	case token.IMPORT:
+		return p.parseImportDeclaration()
+	case token.EXT:
+		return p.parseExtensionFunctionDeclaration()
+	case token.IF:
+		return p.parseIfStatement()
+	case token.WHILE:
+		return p.parseWhileStatement()
+	case token.FOR:
+		return p.parseForStatement()
+	case token.RETURN:
+		return p.parseReturnStatement()
+	case token.BREAK:
+		return p.parseBreakStatement()
+	case token.CONTINUE:
+		return p.parseContinueStatement()
+	case token.MATCH:
+		return p.parseMatchStatement()
+	case token.USING:
+		return p.parseUsingStatement()
+	case token.TRY:
+		return p.parseTryStatement()
+	case token.THROW:
+		return p.parseThrowStatement()
+	case token.CONDITION:
+		return p.parseConditionStatement()
+	case token.LBRACE:
+		return p.parseBlockStatement()
+	default:
+		return p.parseExpressionStatement()
+	}
+}
+
+func (p *Parser) parseModuleDeclaration() ast.ProgramItem {
+	module := &ast.ModuleDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	module.Name = p.currentIdentifier()
+
+	if !p.expectPeek(token.LBRACE) {
+		return nil
+	}
+	block := p.parseBlockStatement()
+	module.Body = block
+	if block != nil {
+		module.Finish = block.End()
+	} else {
+		module.Finish = p.curToken.End
+	}
+	return module
+}
+
+func (p *Parser) parsePackageDeclaration() ast.ProgramItem {
+	pkg := &ast.PackageDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	pkg.Name = p.currentIdentifier()
+	pkg.Finish = pkg.Name.End()
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		pkg.Finish = p.curToken.End
+	}
+	return pkg
+}
+
+func (p *Parser) parseVariableDeclaration() ast.Statement {
+	stmt := &ast.VariableDeclaration{Start: p.curToken.Pos, Mutable: p.curToken.Type == token.VAR}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	stmt.Name = p.currentIdentifier()
+
+	if p.peekTokenIs(token.COLON) {
+		p.nextToken()
+		p.nextToken()
+		stmt.Type = p.parseTypeAnnotation()
+	}
+
+	if !p.expectPeek(token.ASSIGN) {
+		return nil
+	}
+
+	p.nextToken()
+	stmt.Value = p.parseExpression(LOWEST)
+	if stmt.Value != nil {
+		stmt.Finish = stmt.Value.End()
+	}
+
+	if !p.expectPeek(token.SEMICOLON) {
+		return stmt
+	}
+	stmt.Finish = p.curToken.End
+	return stmt
+}
+
+func (p *Parser) parseFunctionDeclaration() ast.Statement {
+	fn := &ast.FunctionDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	fn.Name = p.currentIdentifier()
+
+	if p.peekTokenIs(token.LT) {
+		fn.TypeParams = p.parseTypeParameters()
+	}
+
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+	p.nextToken()
+	fn.Params = p.parseParameterList(token.RPAREN)
+
+	if p.peekTokenIs(token.COLON) {
+		p.nextToken()
+		p.nextToken()
+		fn.ReturnType = p.parseTypeAnnotation()
+	}
+
+	if p.peekTokenIs(token.ASYNC) {
+		p.nextToken()
+		fn.Async = true
+	}
+
+	if p.peekTokenIs(token.CONTRACT) {
+		p.nextToken()
+		fn.Contract = p.parseContractBlock()
+	}
+
+	if p.peekTokenIs(token.LBRACE) {
+		p.nextToken()
+		fn.Body = p.parseBlockStatement()
+		if fn.Body != nil {
+			fn.Finish = fn.Body.End()
+		}
+	} else if p.peekTokenIs(token.ASSIGN) || p.peekTokenIs(token.ARROW) {
+		p.nextToken()
+		p.nextToken()
+		fn.IsExprBody = true
+		fn.BodyExpr = p.parseExpression(LOWEST)
+		if fn.BodyExpr != nil {
+			fn.Finish = fn.BodyExpr.End()
+		}
+		if p.peekTokenIs(token.SEMICOLON) {
+			p.nextToken()
+			fn.Finish = p.curToken.End
+		}
+	} else {
+		fn.Finish = p.curToken.End
+	}
+
+	return fn
+}
+
+func (p *Parser) parseExtensionFunctionDeclaration() ast.Statement {
+	fn := &ast.FunctionDeclaration{Start: p.curToken.Pos, IsExtension: true}
+	if !p.expectPeek(token.FN) {
+		return nil
+	}
+
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	fn.Receiver = p.parseTypeAnnotation()
+	if fn.Receiver == nil {
+		return fn
+	}
+
+	if !p.expectPeek(token.DOT) {
+		return fn
+	}
+
+	if !p.expectPeek(token.IDENT) {
+		return fn
+	}
+	fn.Name = p.currentIdentifier()
+
+	if p.peekTokenIs(token.LT) {
+		fn.TypeParams = p.parseTypeParameters()
+	}
+
+	if !p.expectPeek(token.LPAREN) {
+		return fn
+	}
+	p.nextToken()
+	fn.Params = p.parseParameterList(token.RPAREN)
+
+	if p.peekTokenIs(token.COLON) {
+		p.nextToken()
+		p.nextToken()
+		fn.ReturnType = p.parseTypeAnnotation()
+	}
+
+	if p.peekTokenIs(token.ASYNC) {
+		p.nextToken()
+		fn.Async = true
+	}
+
+	if p.peekTokenIs(token.CONTRACT) {
+		p.nextToken()
+		fn.Contract = p.parseContractBlock()
+	}
+
+	if p.peekTokenIs(token.LBRACE) {
+		p.nextToken()
+		fn.Body = p.parseBlockStatement()
+		if fn.Body != nil {
+			fn.Finish = fn.Body.End()
+		}
+	} else if p.peekTokenIs(token.ASSIGN) || p.peekTokenIs(token.ARROW) {
+		p.nextToken()
+		p.nextToken()
+		fn.IsExprBody = true
+		fn.BodyExpr = p.parseExpression(LOWEST)
+		if fn.BodyExpr != nil {
+			fn.Finish = fn.BodyExpr.End()
+		}
+		if p.peekTokenIs(token.SEMICOLON) {
+			p.nextToken()
+			fn.Finish = p.curToken.End
+		}
+	} else {
+		fn.Finish = p.curToken.End
+	}
+
+	return fn
+}
+
+func (p *Parser) parseClassDeclaration() ast.Statement {
+	class := &ast.ClassDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	class.Name = p.currentIdentifier()
+
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+	p.nextToken()
+	class.Params = p.parseParameterList(token.RPAREN)
+
+	if p.peekTokenIs(token.COLON) {
+		p.nextToken()
+		if !p.expectPeek(token.IDENT) {
+			return class
+		}
+		class.SuperClass = p.currentIdentifier()
+	}
+
+	if p.peekTokenIs(token.LBRACE) {
+		p.nextToken()
+		class.Body = p.parseBlockStatement()
+		if class.Body != nil {
+			class.Finish = class.Body.End()
+		}
+	} else {
+		class.Finish = p.curToken.End
+	}
+	return class
+}
+
+func (p *Parser) parseStructDeclaration() ast.Statement {
+	st := &ast.StructDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	st.Name = p.currentIdentifier()
+
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+	p.nextToken()
+	st.Params = p.parseParameterList(token.RPAREN)
+
+	if p.peekTokenIs(token.LBRACE) {
+		p.nextToken()
+		st.Body = p.parseBlockStatement()
+		if st.Body != nil {
+			st.Finish = st.Body.End()
+		}
+	} else {
+		st.Finish = p.curToken.End
+	}
+	return st
+}
+
+func (p *Parser) parseInterfaceDeclaration() ast.Statement {
+	iface := &ast.InterfaceDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	iface.Name = p.currentIdentifier()
+
+	if !p.expectPeek(token.LBRACE) {
+		return iface
+	}
+
+	p.nextToken()
+	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
+		if p.curToken.Type == token.FN {
+			if method := p.parseInterfaceMethod(); method != nil {
+				iface.Methods = append(iface.Methods, *method)
+				iface.Finish = method.End()
+			}
+		} else if p.curToken.Type == token.SEMICOLON {
+			// skip optional semicolons
+		} else {
+			p.errors = append(p.errors, fmt.Sprintf("expected function signature in interface, got %s", p.curToken.Type))
+			return iface
+		}
+
+		if p.peekTokenIs(token.SEMICOLON) {
+			p.nextToken()
+		}
+		p.nextToken()
+	}
+
+	if p.curTokenIs(token.RBRACE) {
+		iface.Finish = p.curToken.End
+	}
+	return iface
+}
+
+func (p *Parser) parseInterfaceMethod() *ast.InterfaceMethod {
+	method := &ast.InterfaceMethod{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	method.Name = p.currentIdentifier()
+
+	if !p.expectPeek(token.LPAREN) {
+		return method
+	}
+
+	p.nextToken()
+	method.Params = p.parseParameterList(token.RPAREN)
+
+	if p.peekTokenIs(token.COLON) {
+		p.nextToken()
+		p.nextToken()
+		method.ReturnType = p.parseTypeAnnotation()
+	}
+
+	method.Finish = p.curToken.End
+	return method
+}
+
+func (p *Parser) parseEnumDeclaration() ast.Statement {
+	enumNode := &ast.EnumDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	enumNode.Name = p.currentIdentifier()
+
+	if p.peekTokenIs(token.LT) {
+		enumNode.TypeParams = p.parseTypeParameters()
+	}
+
+	if !p.expectPeek(token.LBRACE) {
+		return nil
+	}
+	p.nextToken()
+	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
+		caseNode := p.parseEnumCase()
+		if caseNode != nil {
+			enumNode.Cases = append(enumNode.Cases, *caseNode)
+			enumNode.Finish = caseNode.End()
+		}
+		p.nextToken()
+	}
+	if p.curTokenIs(token.RBRACE) {
+		enumNode.Finish = p.curToken.End
+	}
+	return enumNode
+}
+
+func (p *Parser) parseEnumCase() *ast.EnumCase {
+	caseNode := &ast.EnumCase{Start: p.curToken.Pos}
+	if p.curToken.Type != token.IDENT {
+		p.errors = append(p.errors, fmt.Sprintf("expected enum case identifier, got %s", p.curToken.Type))
+		return nil
+	}
+	caseNode.Name = p.currentIdentifier()
+
+	if p.peekTokenIs(token.LPAREN) {
+		p.nextToken()
+		p.nextToken()
+		caseNode.Params = p.parseParameterList(token.RPAREN)
+	}
+
+	if !p.expectPeek(token.SEMICOLON) {
+		return caseNode
+	}
+	caseNode.Finish = p.curToken.End
+	return caseNode
+}
+
+func (p *Parser) parseContractDeclaration() ast.Statement {
+	contract := &ast.ContractDeclaration{Start: p.curToken.Pos}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	contract.Name = p.currentIdentifier()
+
+	if !p.expectPeek(token.LBRACE) {
+		return contract
+	}
+	contract.Body = p.parseBlockStatement()
+	if contract.Body != nil {
+		contract.Finish = contract.Body.End()
+	}
+	return contract
+}
+
+func (p *Parser) parseImportDeclaration() ast.Statement {
+	imp := &ast.ImportDeclaration{Start: p.curToken.Pos}
+
+	if !(p.peekTokenIs(token.STRING) || p.peekTokenIs(token.IDENT)) {
+		p.peekError(token.IDENT)
+		return imp
+	}
+
+	p.nextToken()
+
+	if p.curToken.Type == token.IDENT && p.peekTokenIs(token.STRING) {
+		imp.Alias = p.currentIdentifier()
+		p.nextToken()
+	}
+
+	switch p.curToken.Type {
+	case token.STRING:
+		imp.PathLiteral = p.curToken.Literal
+		segments := strings.Split(imp.PathLiteral, "/")
+		for _, segment := range segments {
+			if segment == "" {
+				continue
+			}
+			imp.Path = append(imp.Path, &ast.Identifier{Name: segment, Start: p.curToken.Pos, Finish: p.curToken.End})
+		}
+	case token.IDENT:
+		imp.Path = append(imp.Path, p.currentIdentifier())
+		for p.peekTokenIs(token.DOT) {
+			p.nextToken()
+			if !p.expectPeek(token.IDENT) {
+				return imp
+			}
+			imp.Path = append(imp.Path, p.currentIdentifier())
+		}
+		if p.peekTokenIs(token.AS) {
+			p.nextToken()
+			if !p.expectPeek(token.IDENT) {
+				return imp
+			}
+			imp.Alias = p.currentIdentifier()
+		}
+	default:
+		p.peekError(token.IDENT)
+		return imp
+	}
+
+	if imp.PathLiteral != "" && imp.Alias == nil && p.peekTokenIs(token.AS) {
+		p.nextToken()
+		if !p.expectPeek(token.IDENT) {
+			return imp
+		}
+		imp.Alias = p.currentIdentifier()
+	}
+
+	if !p.expectPeek(token.SEMICOLON) {
+		return imp
+	}
+	imp.Finish = p.curToken.End
+	return imp
+}
+
+func (p *Parser) parseIfStatement() ast.Statement {
+	stmt := &ast.IfStatement{Start: p.curToken.Pos}
+	p.nextToken()
+	stmt.Condition = p.parseExpression(LOWEST)
+	if stmt.Condition != nil {
+		stmt.Finish = stmt.Condition.End()
+	}
+	if !p.expectPeek(token.LBRACE) {
+		return stmt
+	}
+	stmt.Consequence = p.parseBlockStatement()
+	if stmt.Consequence != nil {
+		stmt.Finish = stmt.Consequence.End()
+	}
+	if p.peekTokenIs(token.ELSE) {
+		p.nextToken()
+		p.nextToken()
+		alt := p.parseStatement()
+		stmt.Alternative = alt
+		if alt != nil {
+			stmt.Finish = alt.End()
+		}
+	}
+	return stmt
+}
+
+func (p *Parser) parseWhileStatement() ast.Statement {
+	stmt := &ast.WhileStatement{Start: p.curToken.Pos}
+	p.nextToken()
+	stmt.Condition = p.parseExpression(LOWEST)
+	if stmt.Condition != nil {
+		stmt.Finish = stmt.Condition.End()
+	}
+	if !p.expectPeek(token.LBRACE) {
+		return stmt
+	}
+	stmt.Body = p.parseBlockStatement()
+	if stmt.Body != nil {
+		stmt.Finish = stmt.Body.End()
+	}
+	return stmt
+}
+
+func (p *Parser) parseForStatement() ast.Statement {
+	stmt := &ast.ForStatement{Start: p.curToken.Pos}
+	if !p.expectPeek(token.LPAREN) {
+		return stmt
+	}
+	p.nextToken()
+
+	if !p.curTokenIs(token.SEMICOLON) {
+		if p.curToken.Type == token.LET || p.curToken.Type == token.VAR {
+			init := p.parseVariableDeclaration()
+			stmt.Init = init
+			if init != nil {
+				stmt.Finish = init.End()
+			}
+		} else {
+			expr := p.parseExpression(LOWEST)
+			if expr != nil {
+				stmt.Init = &ast.ExpressionStatement{Expression: expr, Start: expr.Pos(), Finish: expr.End()}
+				stmt.Finish = expr.End()
+			}
+			if !p.expectPeek(token.SEMICOLON) {
+				return stmt
+			}
+		}
+	}
+
+	if !p.curTokenIs(token.SEMICOLON) {
+		if !p.expectPeek(token.SEMICOLON) {
+			return stmt
+		}
+	}
+
+	p.nextToken()
+	if !p.curTokenIs(token.SEMICOLON) {
+		stmt.Condition = p.parseExpression(LOWEST)
+		if stmt.Condition != nil {
+			stmt.Finish = stmt.Condition.End()
+		}
+		if !p.expectPeek(token.SEMICOLON) {
+			return stmt
+		}
+	}
+
+	p.nextToken()
+	if !p.curTokenIs(token.RPAREN) {
+		stmt.Post = p.parseExpression(LOWEST)
+		if stmt.Post != nil {
+			stmt.Finish = stmt.Post.End()
+		}
+		if !p.expectPeek(token.RPAREN) {
+			return stmt
+		}
+	}
+	if !p.expectPeek(token.LBRACE) {
+		return stmt
+	}
+	stmt.Body = p.parseBlockStatement()
+	if stmt.Body != nil {
+		stmt.Finish = stmt.Body.End()
+	}
+	return stmt
+}
+
+func (p *Parser) parseUsingStatement() ast.Statement {
+	stmt := &ast.UsingStatement{Start: p.curToken.Pos}
+	p.nextToken()
+
+	if p.curToken.Type == token.IDENT && p.peekTokenIs(token.ASSIGN) {
+		stmt.Name = p.currentIdentifier()
+		p.nextToken()
+		p.nextToken()
+		stmt.Value = p.parseExpression(LOWEST)
+	} else {
+		stmt.Value = p.parseExpression(LOWEST)
+	}
+
+	if stmt.Value != nil {
+		stmt.Finish = stmt.Value.End()
+	}
+
+	if !p.expectPeek(token.LBRACE) {
+		return stmt
+	}
+	stmt.Body = p.parseBlockStatement()
+	if stmt.Body != nil {
+		stmt.Finish = stmt.Body.End()
+	}
+	return stmt
+}
+
+func (p *Parser) parseThrowStatement() ast.Statement {
+	stmt := &ast.ThrowStatement{Start: p.curToken.Pos}
+	p.nextToken()
+	stmt.Value = p.parseExpression(LOWEST)
+	if stmt.Value != nil {
+		stmt.Finish = stmt.Value.End()
+	} else {
+		stmt.Finish = p.curToken.End
+	}
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		stmt.Finish = p.curToken.End
+	}
+	return stmt
+}
+
+func (p *Parser) parseReturnStatement() ast.Statement {
+	stmt := &ast.ReturnStatement{Start: p.curToken.Pos}
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		stmt.Finish = p.curToken.End
+		return stmt
+	}
+	p.nextToken()
+	stmt.Value = p.parseExpression(LOWEST)
+	if stmt.Value != nil {
+		stmt.Finish = stmt.Value.End()
+	}
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		stmt.Finish = p.curToken.End
+	}
+	return stmt
+}
+
+func (p *Parser) parseBreakStatement() ast.Statement {
+	stmt := &ast.BreakStatement{Start: p.curToken.Pos, Finish: p.curToken.End}
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		stmt.Finish = p.curToken.End
+	}
+	return stmt
+}
+
+func (p *Parser) parseContinueStatement() ast.Statement {
+	stmt := &ast.ContinueStatement{Start: p.curToken.Pos, Finish: p.curToken.End}
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		stmt.Finish = p.curToken.End
+	}
+	return stmt
+}
+
+func (p *Parser) parseMatchStatement() ast.Statement {
+	match := &ast.MatchStatement{Start: p.curToken.Pos}
+	p.nextToken()
+	match.Value = p.parseExpression(LOWEST)
+	if !p.expectPeek(token.LBRACE) {
+		return match
+	}
+	p.nextToken()
+	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
+		caseNode := p.parseMatchCase()
+		if caseNode != nil {
+			match.Cases = append(match.Cases, *caseNode)
+			match.Finish = caseNode.End()
+		}
+		p.nextToken()
+	}
+	if p.curTokenIs(token.RBRACE) {
+		match.Finish = p.curToken.End
+	}
+	return match
+}
+
+func (p *Parser) parseMatchCase() *ast.MatchCase {
+	caseNode := &ast.MatchCase{Start: p.curToken.Pos}
+	pattern := p.parsePattern()
+	caseNode.Pattern = pattern
+
+	if !p.expectPeek(token.ARROW) {
+		return caseNode
+	}
+	p.nextToken()
+	body := p.parseStatement()
+	caseNode.Body = body
+	if body != nil {
+		caseNode.Finish = body.End()
+	}
+	return caseNode
+}
+
+func (p *Parser) parseTryStatement() ast.Statement {
+	stmt := &ast.TryStatement{Start: p.curToken.Pos}
+	if !p.expectPeek(token.LBRACE) {
+		return stmt
+	}
+	stmt.Body = p.parseBlockStatement()
+	if stmt.Body != nil {
+		stmt.Finish = stmt.Body.End()
+	}
+
+	if p.peekTokenIs(token.CATCH) {
+		p.nextToken()
+		stmt.Catch = p.parseCatchClause()
+		if stmt.Catch != nil {
+			stmt.Finish = stmt.Catch.End()
+		}
+	}
+
+	if p.peekTokenIs(token.FINALLY) {
+		p.nextToken()
+		if !p.expectPeek(token.LBRACE) {
+			return stmt
+		}
+		stmt.Finally = p.parseBlockStatement()
+		if stmt.Finally != nil {
+			stmt.Finish = stmt.Finally.End()
+		}
+	}
+
+	if stmt.Finish.Line == 0 && stmt.Body != nil {
+		stmt.Finish = stmt.Body.End()
+	}
+	return stmt
+}
+
+func (p *Parser) parseCatchClause() *ast.CatchClause {
+	clause := &ast.CatchClause{Start: p.curToken.Pos}
+	if p.peekTokenIs(token.LPAREN) {
+		p.nextToken()
+		if p.peekTokenIs(token.IDENT) {
+			p.nextToken()
+			clause.Identifier = p.currentIdentifier()
+		}
+		if !p.expectPeek(token.RPAREN) {
+			return clause
+		}
+	}
+
+	if !p.expectPeek(token.LBRACE) {
+		return clause
+	}
+	clause.Body = p.parseBlockStatement()
+	if clause.Body != nil {
+		clause.Finish = clause.Body.End()
+	}
+	return clause
+}
+
+func (p *Parser) parseConditionStatement() ast.Statement {
+	stmt := &ast.ConditionStatement{Start: p.curToken.Pos}
+	if !p.expectPeek(token.LBRACE) {
+		return stmt
+	}
+
+	p.nextToken()
+	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
+		switch p.curToken.Type {
+		case token.WHEN:
+			clause := ast.ConditionClause{Start: p.curToken.Pos}
+			p.nextToken()
+			clause.Test = p.parseExpression(LOWEST)
+			if clause.Test != nil {
+				clause.Finish = clause.Test.End()
+			}
+			if !p.expectPeek(token.ARROW) {
+				return stmt
+			}
+			if !p.expectPeek(token.LBRACE) {
+				return stmt
+			}
+			clause.Body = p.parseBlockStatement()
+			if clause.Body != nil {
+				clause.Finish = clause.Body.End()
+			}
+			stmt.Clauses = append(stmt.Clauses, clause)
+		case token.ELSE:
+			if !p.expectPeek(token.ARROW) {
+				return stmt
+			}
+			if !p.expectPeek(token.LBRACE) {
+				return stmt
+			}
+			stmt.Else = p.parseBlockStatement()
+			if stmt.Else != nil {
+				stmt.Finish = stmt.Else.End()
+			}
+		case token.SEMICOLON:
+			// skip
+		default:
+			p.errors = append(p.errors, fmt.Sprintf("expected 'when' or 'else' in condition block, got %s", p.curToken.Type))
+			return stmt
+		}
+		p.nextToken()
+	}
+
+	if p.curTokenIs(token.RBRACE) {
+		stmt.Finish = p.curToken.End
+	}
+	return stmt
+}
+
+func (p *Parser) parseBlockStatement() *ast.BlockStatement {
+	block := &ast.BlockStatement{Start: p.curToken.Pos}
+	p.nextToken()
+	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
+		stmt := p.parseStatement()
+		if stmt != nil {
+			block.Statements = append(block.Statements, stmt)
+		}
+		p.nextToken()
+	}
+	block.Finish = p.curToken.End
+	return block
+}
+
+func (p *Parser) parseExpressionStatement() ast.Statement {
+	stmt := &ast.ExpressionStatement{Start: p.curToken.Pos}
+	stmt.Expression = p.parseExpression(LOWEST)
+	if stmt.Expression != nil {
+		stmt.Finish = stmt.Expression.End()
+	}
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		stmt.Finish = p.curToken.End
+	}
+	return stmt
+}
+
+func (p *Parser) parseTypeParameters() []*ast.Identifier {
+	params := []*ast.Identifier{}
+	if !p.expectPeek(token.LT) {
+		return params
+	}
+	if !p.expectPeek(token.IDENT) {
+		return params
+	}
+	params = append(params, p.currentIdentifier())
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		if !p.expectPeek(token.IDENT) {
+			return params
+		}
+		params = append(params, p.currentIdentifier())
+	}
+	if !p.expectPeek(token.GT) {
+		return params
+	}
+	return params
+}
+
+func (p *Parser) parseParameterList(end token.Type) []ast.Parameter {
+	params := []ast.Parameter{}
+	if p.curTokenIs(end) {
+		return params
+	}
+	param := p.parseParameter()
+	params = append(params, param)
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		params = append(params, p.parseParameter())
+	}
+	if !p.expectPeek(end) {
+		return params
+	}
+	return params
+}
+
+func (p *Parser) parseParameter() ast.Parameter {
+	param := ast.Parameter{}
+	if p.curToken.Type != token.IDENT {
+		p.errors = append(p.errors, fmt.Sprintf("expected parameter name, got %s", p.curToken.Type))
+		return param
+	}
+	param.Name = p.currentIdentifier()
+	if !p.expectPeek(token.COLON) {
+		return param
+	}
+	p.nextToken()
+	param.Type = p.parseTypeAnnotation()
+	return param
+}
+
+func (p *Parser) parseTypeAnnotation() *ast.TypeAnnotation {
+	if p.curToken.Type != token.IDENT {
+		p.errors = append(p.errors, fmt.Sprintf("expected type identifier, got %s", p.curToken.Type))
+		return nil
+	}
+	typeNode := &ast.TypeAnnotation{Start: p.curToken.Pos}
+	typeNode.Name = p.currentIdentifier()
+
+	if p.peekTokenIs(token.LT) {
+		p.nextToken()
+		p.nextToken()
+		if arg := p.parseTypeAnnotation(); arg != nil {
+			typeNode.TypeArgs = append(typeNode.TypeArgs, arg)
+		}
+		for p.peekTokenIs(token.COMMA) {
+			p.nextToken()
+			p.nextToken()
+			if arg := p.parseTypeAnnotation(); arg != nil {
+				typeNode.TypeArgs = append(typeNode.TypeArgs, arg)
+			}
+		}
+		if !p.expectPeek(token.GT) {
+			return typeNode
+		}
+	}
+
+	if p.peekTokenIs(token.QUESTION) {
+		p.nextToken()
+		typeNode.Nullable = true
+	}
+
+	typeNode.Finish = p.curToken.End
+	return typeNode
+}
+
+func (p *Parser) parseContractBlock() *ast.ContractBlock {
+	block := &ast.ContractBlock{Start: p.curToken.Pos}
+	if !p.expectPeek(token.LBRACE) {
+		return block
+	}
+	p.nextToken()
+	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
+		clause := p.parseContractClause()
+		if clause != nil {
+			block.Clauses = append(block.Clauses, *clause)
+		}
+		p.nextToken()
+	}
+	block.Finish = p.curToken.End
+	return block
+}
+
+func (p *Parser) parseContractClause() *ast.ContractClause {
+	clause := &ast.ContractClause{Start: p.curToken.Pos}
+	if p.curToken.Type != token.RETURNS {
+		p.errors = append(p.errors, fmt.Sprintf("expected 'returns' in contract clause, got %s", p.curToken.Type))
+		return nil
+	}
+	if !p.expectPeek(token.LPAREN) {
+		return clause
+	}
+	if !p.peekTokenIs(token.RPAREN) {
+		p.nextToken()
+		clause.Guard = p.parseExpression(LOWEST)
+	}
+	if !p.expectPeek(token.RPAREN) {
+		return clause
+	}
+	if !p.expectPeek(token.ARROW) {
+		return clause
+	}
+	p.nextToken()
+	clause.Condition = p.parseExpression(LOWEST)
+	if !p.expectPeek(token.SEMICOLON) {
+		return clause
+	}
+	clause.Finish = p.curToken.End
+	return clause
+}
+
+func (p *Parser) parsePattern() ast.Pattern {
+	switch p.curToken.Type {
+	case token.NUMBER:
+		node := &ast.NumberLiteral{Value: p.curToken.Literal, Start: p.curToken.Pos, Finish: p.curToken.End}
+		return &ast.LiteralPattern{Value: node}
+	case token.STRING:
+		node := &ast.StringLiteral{Value: p.curToken.Literal, Start: p.curToken.Pos, Finish: p.curToken.End}
+		return &ast.LiteralPattern{Value: node}
+	case token.TRUE, token.FALSE:
+		node := &ast.BooleanLiteral{Value: p.curToken.Type == token.TRUE, Start: p.curToken.Pos, Finish: p.curToken.End}
+		return &ast.LiteralPattern{Value: node}
+	case token.NULL:
+		node := &ast.NullLiteral{Start: p.curToken.Pos, Finish: p.curToken.End}
+		return &ast.LiteralPattern{Value: node}
+	case token.IDENT:
+		ident := p.currentIdentifier()
+		if p.peekTokenIs(token.LPAREN) {
+			return p.parseStructPattern(ident)
+		}
+		return &ast.IdentifierPattern{Identifier: ident}
+	case token.LBRACE:
+		return p.parseObjectPattern()
+	default:
+		p.errors = append(p.errors, fmt.Sprintf("unexpected token in pattern: %s", p.curToken.Type))
+		return nil
+	}
+}
+
+func (p *Parser) parseStructPattern(name *ast.Identifier) ast.Pattern {
+	pattern := &ast.StructPattern{Name: name, Start: name.Pos()}
+	if !p.expectPeek(token.LPAREN) {
+		return pattern
+	}
+	p.nextToken()
+	if p.curTokenIs(token.RPAREN) {
+		pattern.Finish = p.curToken.End
+		return pattern
+	}
+	pattern.Fields = append(pattern.Fields, p.parsePattern())
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		pattern.Fields = append(pattern.Fields, p.parsePattern())
+	}
+	if !p.expectPeek(token.RPAREN) {
+		return pattern
+	}
+	pattern.Finish = p.curToken.End
+	return pattern
+}
+
+func (p *Parser) parseObjectPattern() ast.Pattern {
+	pattern := &ast.ObjectPattern{Start: p.curToken.Pos}
+	p.nextToken()
+	if p.curTokenIs(token.RBRACE) {
+		pattern.Finish = p.curToken.End
+		return pattern
+	}
+	pattern.Pairs = append(pattern.Pairs, p.parsePatternPair())
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		pattern.Pairs = append(pattern.Pairs, p.parsePatternPair())
+	}
+	if !p.expectPeek(token.RBRACE) {
+		return pattern
+	}
+	pattern.Finish = p.curToken.End
+	return pattern
+}
+
+func (p *Parser) parsePatternPair() ast.PatternPair {
+	pair := ast.PatternPair{}
+	keyToken := p.curToken
+	if keyToken.Type != token.STRING && keyToken.Type != token.IDENT {
+		p.errors = append(p.errors, fmt.Sprintf("expected pattern key, got %s", keyToken.Type))
+		return pair
+	}
+	pair.Key = keyToken.Literal
+	pair.KeyIsIdentifier = keyToken.Type == token.IDENT
+	if !p.expectPeek(token.COLON) {
+		return pair
+	}
+	p.nextToken()
+	pair.Value = p.parsePattern()
+	return pair
+}
+
+func (p *Parser) parseIdentifier() ast.Expression {
+	return p.currentIdentifier()
+}
+
+func (p *Parser) parseNumberLiteral() ast.Expression {
+	lit := &ast.NumberLiteral{Value: p.curToken.Literal, Start: p.curToken.Pos, Finish: p.curToken.End}
+	return lit
+}
+
+func (p *Parser) parseStringLiteral() ast.Expression {
+	lit := &ast.StringLiteral{Value: p.curToken.Literal, Start: p.curToken.Pos, Finish: p.curToken.End}
+	switch p.curToken.Type {
+	case token.RAWSTRING:
+		lit.Raw = true
+	case token.FORMATSTRING:
+		lit.Format = true
+	}
+	return lit
+}
+
+func (p *Parser) parseBooleanLiteral() ast.Expression {
+	return &ast.BooleanLiteral{Value: p.curToken.Type == token.TRUE, Start: p.curToken.Pos, Finish: p.curToken.End}
+}
+
+func (p *Parser) parseNullLiteral() ast.Expression {
+	return &ast.NullLiteral{Start: p.curToken.Pos, Finish: p.curToken.End}
+}
+
+func (p *Parser) parsePrefixExpression() ast.Expression {
+	expr := &ast.PrefixExpression{Operator: p.curToken.Literal, Start: p.curToken.Pos}
+	p.nextToken()
+	expr.Right = p.parseExpression(PREFIX)
+	if expr.Right != nil {
+		expr.Finish = expr.Right.End()
+	} else {
+		expr.Finish = p.curToken.End
+	}
+	return expr
+}
+
+func (p *Parser) parseGroupedExpression() ast.Expression {
+	p.nextToken()
+	exp := p.parseExpression(LOWEST)
+	if !p.expectPeek(token.RPAREN) {
+		return nil
+	}
+	return exp
+}
+
+func (p *Parser) parseArrayLiteral() ast.Expression {
+	array := &ast.ArrayLiteral{Start: p.curToken.Pos}
+	if p.peekTokenIs(token.RBRACKET) {
+		p.nextToken()
+		array.Finish = p.curToken.End
+		return array
+	}
+	p.nextToken()
+	array.Elements = append(array.Elements, p.parseExpression(LOWEST))
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		array.Elements = append(array.Elements, p.parseExpression(LOWEST))
+	}
+	if !p.expectPeek(token.RBRACKET) {
+		return array
+	}
+	array.Finish = p.curToken.End
+	return array
+}
+
+func (p *Parser) parseObjectLiteral() ast.Expression {
+	obj := &ast.ObjectLiteral{Start: p.curToken.Pos}
+	if p.peekTokenIs(token.RBRACE) {
+		p.nextToken()
+		obj.Finish = p.curToken.End
+		return obj
+	}
+	p.nextToken()
+	obj.Pairs = append(obj.Pairs, p.parseObjectPair())
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		obj.Pairs = append(obj.Pairs, p.parseObjectPair())
+	}
+	if !p.expectPeek(token.RBRACE) {
+		return obj
+	}
+	obj.Finish = p.curToken.End
+	return obj
+}
+
+func (p *Parser) parseObjectPair() ast.ObjectPair {
+	pair := ast.ObjectPair{}
+	keyToken := p.curToken
+	if keyToken.Type != token.STRING && keyToken.Type != token.IDENT {
+		p.errors = append(p.errors, fmt.Sprintf("expected object key, got %s", keyToken.Type))
+		return pair
+	}
+	pair.Key = keyToken.Literal
+	pair.KeyIsIdentifier = keyToken.Type == token.IDENT
+	if !p.expectPeek(token.COLON) {
+		return pair
+	}
+	p.nextToken()
+	pair.Value = p.parseExpression(LOWEST)
+	return pair
+}
+
+func (p *Parser) parseAwaitExpression() ast.Expression {
+	expr := &ast.AwaitExpression{Start: p.curToken.Pos}
+	p.nextToken()
+	expr.Expression = p.parseExpression(PREFIX)
+	if expr.Expression != nil {
+		expr.Finish = expr.Expression.End()
+	}
+	return expr
+}
+
+func (p *Parser) parseInfixExpression(left ast.Expression) ast.Expression {
+	expr := &ast.InfixExpression{Left: left, Operator: p.curToken.Literal, Start: left.Pos()}
+	precedence := p.curPrecedence()
+	p.nextToken()
+	expr.Right = p.parseExpression(precedence)
+	if expr.Right != nil {
+		expr.Finish = expr.Right.End()
+	} else {
+		expr.Finish = p.curToken.End
+	}
+	return expr
+}
+
+func (p *Parser) parseElvisExpression(left ast.Expression) ast.Expression {
+	expr := &ast.ElvisExpression{Left: left, Start: left.Pos()}
+	p.nextToken()
+	expr.Right = p.parseExpression(ELVIS - 1)
+	if expr.Right != nil {
+		expr.Finish = expr.Right.End()
+	}
+	return expr
+}
+
+func (p *Parser) parseAssignmentExpression(left ast.Expression) ast.Expression {
+	expr := &ast.AssignmentExpression{Target: left, Operator: p.curToken.Type, Start: left.Pos()}
+	precedence := p.curPrecedence()
+	p.nextToken()
+	expr.Value = p.parseExpression(precedence - 1)
+	if expr.Value != nil {
+		expr.Finish = expr.Value.End()
+	}
+	return expr
+}
+
+func (p *Parser) parseCallExpression(function ast.Expression) ast.Expression {
+	exp := &ast.CallExpression{Callee: function, Start: function.Pos()}
+	exp.Arguments = p.parseExpressionList(token.RPAREN)
+	exp.Finish = p.curToken.End
+	return exp
+}
+
+func (p *Parser) parseIndexExpression(left ast.Expression) ast.Expression {
+	exp := &ast.IndexExpression{Collection: left, Start: left.Pos()}
+	p.nextToken()
+	exp.Index = p.parseExpression(LOWEST)
+	if !p.expectPeek(token.RBRACKET) {
+		return exp
+	}
+	exp.Finish = p.curToken.End
+	return exp
+}
+
+func (p *Parser) parseMemberExpression(object ast.Expression) ast.Expression {
+	member := &ast.MemberExpression{Object: object, Optional: p.curToken.Type == token.SAFE_DOT, Start: object.Pos()}
+	if !p.expectPeek(token.IDENT) {
+		return member
+	}
+	member.Property = p.curToken.Literal
+	member.Finish = p.curToken.End
+	return member
+}
+
+func (p *Parser) parseNonNullAssertion(left ast.Expression) ast.Expression {
+	assertion := &ast.NonNullAssertion{Expression: left, Start: left.Pos(), Finish: p.curToken.End}
+	return assertion
+}
+
+func (p *Parser) parseExpressionList(end token.Type) []ast.Expression {
+	list := []ast.Expression{}
+	if p.peekTokenIs(end) {
+		p.nextToken()
+		return list
+	}
+	p.nextToken()
+	list = append(list, p.parseExpression(LOWEST))
+	for p.peekTokenIs(token.COMMA) {
+		p.nextToken()
+		p.nextToken()
+		list = append(list, p.parseExpression(LOWEST))
+	}
+	if !p.expectPeek(end) {
+		return list
+	}
+	return list
+}
+
+func (p *Parser) parseExpression(precedence int) ast.Expression {
+	prefix := p.prefixParseFns[p.curToken.Type]
+	if prefix == nil {
+		p.noPrefixParseFnError(p.curToken.Type)
+		return nil
+	}
+	leftExp := prefix()
+
+	for !p.peekTokenIs(token.SEMICOLON) && precedence < p.peekPrecedence() {
+		infix := p.infixParseFns[p.peekToken.Type]
+		if infix == nil {
+			break
+		}
+		p.nextToken()
+		leftExp = infix(leftExp)
+	}
+
+	return leftExp
+}
+
+func (p *Parser) currentIdentifier() *ast.Identifier {
+	return &ast.Identifier{Name: p.curToken.Literal, Start: p.curToken.Pos, Finish: p.curToken.End}
+}
+
+func (p *Parser) expectPeek(t token.Type) bool {
+	if p.peekTokenIs(t) {
+		p.nextToken()
+		return true
+	}
+	p.peekError(t)
+	return false
+}
+
+func (p *Parser) curTokenIs(t token.Type) bool {
+	return p.curToken.Type == t
+}
+
+func (p *Parser) peekTokenIs(t token.Type) bool {
+	return p.peekToken.Type == t
+}
+
+func (p *Parser) peekPrecedence() int {
+	if p, ok := precedences[p.peekToken.Type]; ok {
+		return p
+	}
+	return LOWEST
+}
+
+func (p *Parser) curPrecedence() int {
+	if p, ok := precedences[p.curToken.Type]; ok {
+		return p
+	}
+	return LOWEST
+}
+
+func (p *Parser) peekError(t token.Type) {
+	msg := fmt.Sprintf("expected next token to be %s, got %s instead", t, p.peekToken.Type)
+	p.errors = append(p.errors, msg)
+}
+
+func (p *Parser) noPrefixParseFnError(t token.Type) {
+	msg := fmt.Sprintf("no prefix parse function for %s found", t)
+	p.errors = append(p.errors, msg)
+}

--- a/internal/project/deps.go
+++ b/internal/project/deps.go
@@ -1,0 +1,45 @@
+package project
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// PrepareDependency vendors the module from srcPath into the project and computes its checksum.
+func PrepareDependency(root, module, version, source, srcPath string) (Dependency, LockedDependency, error) {
+	if module == "" {
+		return Dependency{}, LockedDependency{}, errors.New("module path is required")
+	}
+	if version == "" {
+		return Dependency{}, LockedDependency{}, errors.New("version is required")
+	}
+	if srcPath == "" {
+		return Dependency{}, LockedDependency{}, errors.New("source path is required for vendoring")
+	}
+	absSrc, err := filepath.Abs(srcPath)
+	if err != nil {
+		return Dependency{}, LockedDependency{}, err
+	}
+	if info, err := os.Stat(absSrc); err != nil {
+		return Dependency{}, LockedDependency{}, err
+	} else if !info.IsDir() {
+		return Dependency{}, LockedDependency{}, fmt.Errorf("%s is not a directory", absSrc)
+	}
+	if _, err := EnsureVendorTree(root); err != nil {
+		return Dependency{}, LockedDependency{}, err
+	}
+	vendorRel := VendorPath(module, version)
+	vendorDest := filepath.Join(root, vendorRel)
+	if err := CopyIntoVendor(absSrc, vendorDest); err != nil {
+		return Dependency{}, LockedDependency{}, err
+	}
+	checksum, err := HashDirectory(vendorDest)
+	if err != nil {
+		return Dependency{}, LockedDependency{}, err
+	}
+	dep := Dependency{Version: version, Source: source}
+	lock := LockedDependency{Module: module, Version: version, Checksum: checksum, Vendor: vendorRel}
+	return dep, lock, nil
+}

--- a/internal/project/fs.go
+++ b/internal/project/fs.go
@@ -1,0 +1,147 @@
+package project
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// EnsureVendorTree prepares the vendor directory under the root.
+func EnsureVendorTree(root string) (string, error) {
+	vendorPath := filepath.Join(root, VendorDirectory)
+	if err := os.MkdirAll(vendorPath, 0o755); err != nil {
+		return "", err
+	}
+	return vendorPath, nil
+}
+
+// CopyIntoVendor copies the contents of src into the destination directory.
+func CopyIntoVendor(src, dest string) error {
+	if err := os.RemoveAll(dest); err != nil {
+		return err
+	}
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dest, rel)
+		if d.IsDir() {
+			if rel == "." {
+				return os.MkdirAll(dest, 0o755)
+			}
+			return os.MkdirAll(target, 0o755)
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		in, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+		out, err := os.Create(target)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(out, in); err != nil {
+			out.Close()
+			return err
+		}
+		return out.Close()
+	})
+}
+
+// HashDirectory produces a deterministic sha256 digest for the directory contents.
+func HashDirectory(root string) (string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		files = append(files, rel)
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	sort.Strings(files)
+	hasher := sha256.New()
+	for _, rel := range files {
+		filePath := filepath.Join(root, rel)
+		f, err := os.Open(filePath)
+		if err != nil {
+			return "", err
+		}
+		if _, err := hasher.Write([]byte(strings.ReplaceAll(rel, "\\", "/"))); err != nil {
+			f.Close()
+			return "", err
+		}
+		if _, err := hasher.Write([]byte{0}); err != nil {
+			f.Close()
+			return "", err
+		}
+		if _, err := io.Copy(hasher, f); err != nil {
+			f.Close()
+			return "", err
+		}
+		f.Close()
+	}
+	return "sha256-" + hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+// VerifyChecksum recomputes the directory digest and compares it to the expected checksum.
+func VerifyChecksum(path, checksum string) error {
+	digest, err := HashDirectory(path)
+	if err != nil {
+		return err
+	}
+	if digest != checksum {
+		return fmt.Errorf("checksum mismatch: expected %s, got %s", checksum, digest)
+	}
+	return nil
+}
+
+// ListSeleneFiles returns all .selene sources within root, sorted lexicographically.
+func ListSeleneFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) == ".selene" {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(files)
+	return files, nil
+}

--- a/internal/project/manifest.go
+++ b/internal/project/manifest.go
@@ -1,0 +1,397 @@
+package project
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	// ManifestName is the filename for Selene manifests.
+	ManifestName = "selene.toml"
+	// LockName is the filename for Selene dependency locks.
+	LockName = "selene.lock"
+	// VendorDirectory is the root directory for vendored dependencies.
+	VendorDirectory = "vendor"
+)
+
+// Manifest represents the contents of a selene.toml file.
+type Manifest struct {
+	Project struct {
+		Name    string
+		Version string
+		Module  string
+		Entry   string
+	}
+	Docs struct {
+		Paths []string
+	}
+	Examples struct {
+		Roots []string
+	}
+	Dependencies map[string]Dependency
+}
+
+// Dependency describes a module requirement recorded in the manifest.
+type Dependency struct {
+	Version string
+	Source  string
+}
+
+// LockedDependency captures an entry in selene.lock.
+type LockedDependency struct {
+	Module   string
+	Version  string
+	Checksum string
+	Vendor   string
+}
+
+// Lockfile holds the resolved dependency set.
+type Lockfile struct {
+	Dependencies []LockedDependency
+}
+
+// FindRoot walks up from start to locate the nearest selene.toml manifest.
+func FindRoot(start string) (string, error) {
+	dir := start
+	info, err := os.Stat(dir)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		dir = filepath.Dir(dir)
+	}
+	for {
+		candidate := filepath.Join(dir, ManifestName)
+		if _, err := os.Stat(candidate); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fs.ErrNotExist
+		}
+		dir = parent
+	}
+}
+
+// LoadManifest reads and decodes the selene.toml located at root.
+func LoadManifest(root string) (*Manifest, error) {
+	path := filepath.Join(root, ManifestName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	manifest := &Manifest{Dependencies: make(map[string]Dependency)}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	section := ""
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = strings.Trim(line, "[]")
+			continue
+		}
+		switch section {
+		case "project":
+			if err := parseProjectLine(&manifest.Project, line); err != nil {
+				return nil, err
+			}
+		case "docs":
+			if err := parseArrayLine(&manifest.Docs.Paths, line); err != nil {
+				return nil, err
+			}
+		case "examples":
+			if err := parseArrayLine(&manifest.Examples.Roots, line); err != nil {
+				return nil, err
+			}
+		case "dependencies":
+			if err := parseDependencyLine(manifest.Dependencies, line); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func parseProjectLine(project *struct {
+	Name    string
+	Version string
+	Module  string
+	Entry   string
+}, line string) error {
+	key, value, ok := splitKeyValue(line)
+	if !ok {
+		return nil
+	}
+	parsed, err := parseString(value)
+	if err != nil {
+		return err
+	}
+	switch key {
+	case "name":
+		project.Name = parsed
+	case "version":
+		project.Version = parsed
+	case "module":
+		project.Module = parsed
+	case "entry":
+		project.Entry = parsed
+	}
+	return nil
+}
+
+func parseArrayLine(target *[]string, line string) error {
+	key, value, ok := splitKeyValue(line)
+	if !ok {
+		return nil
+	}
+	if key != "paths" && key != "roots" {
+		return nil
+	}
+	arr, err := parseStringArray(value)
+	if err != nil {
+		return err
+	}
+	*target = arr
+	return nil
+}
+
+func parseDependencyLine(deps map[string]Dependency, line string) error {
+	key, value, ok := splitKeyValue(line)
+	if !ok {
+		return nil
+	}
+	name, err := parseString(key)
+	if err != nil {
+		return fmt.Errorf("dependency keys must be quoted: %w", err)
+	}
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "{") || !strings.HasSuffix(value, "}") {
+		return fmt.Errorf("dependency %s must use inline table syntax", name)
+	}
+	inner := strings.TrimSpace(value[1 : len(value)-1])
+	dep := Dependency{}
+	fields := strings.Split(inner, ",")
+	for _, field := range fields {
+		fKey, fValue, ok := splitKeyValue(field)
+		if !ok {
+			continue
+		}
+		parsed, err := parseString(fValue)
+		if err != nil {
+			return err
+		}
+		switch strings.TrimSpace(fKey) {
+		case "version":
+			dep.Version = parsed
+		case "source":
+			dep.Source = parsed
+		}
+	}
+	deps[name] = dep
+	return nil
+}
+
+func splitKeyValue(line string) (string, string, bool) {
+	parts := strings.SplitN(line, "=", 2)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	key := strings.TrimSpace(parts[0])
+	value := strings.TrimSpace(parts[1])
+	return key, value, true
+}
+
+func parseString(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if len(value) < 2 || value[0] != '"' || value[len(value)-1] != '"' {
+		return "", fmt.Errorf("expected quoted string, got %q", value)
+	}
+	return value[1 : len(value)-1], nil
+}
+
+func parseStringArray(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "[") || !strings.HasSuffix(value, "]") {
+		return nil, fmt.Errorf("expected array, got %q", value)
+	}
+	inner := strings.TrimSpace(value[1 : len(value)-1])
+	if inner == "" {
+		return []string{}, nil
+	}
+	parts := strings.Split(inner, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		s, err := parseString(part)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, s)
+	}
+	return result, nil
+}
+
+// SaveManifest writes the manifest back to selene.toml in root.
+func SaveManifest(root string, manifest *Manifest) error {
+	if manifest.Dependencies == nil {
+		manifest.Dependencies = make(map[string]Dependency)
+	}
+	var buf bytes.Buffer
+	buf.WriteString("[project]\n")
+	fmt.Fprintf(&buf, "name = \"%s\"\n", manifest.Project.Name)
+	fmt.Fprintf(&buf, "version = \"%s\"\n", manifest.Project.Version)
+	if manifest.Project.Module != "" {
+		fmt.Fprintf(&buf, "module = \"%s\"\n", manifest.Project.Module)
+	}
+	fmt.Fprintf(&buf, "entry = \"%s\"\n\n", manifest.Project.Entry)
+
+	buf.WriteString("[docs]\n")
+	writeStringArray(&buf, "paths", manifest.Docs.Paths)
+	buf.WriteString("\n")
+
+	buf.WriteString("[examples]\n")
+	writeStringArray(&buf, "roots", manifest.Examples.Roots)
+	buf.WriteString("\n")
+
+	if len(manifest.Dependencies) > 0 {
+		buf.WriteString("[dependencies]\n")
+		modules := SortedModules(manifest.Dependencies)
+		for _, module := range modules {
+			dep := manifest.Dependencies[module]
+			fmt.Fprintf(&buf, "\"%s\" = { version = \"%s\"", module, dep.Version)
+			if dep.Source != "" {
+				fmt.Fprintf(&buf, ", source = \"%s\"", dep.Source)
+			}
+			buf.WriteString(" }\n")
+		}
+	}
+
+	path := filepath.Join(root, ManifestName)
+	return os.WriteFile(path, buf.Bytes(), 0o644)
+}
+
+func writeStringArray(buf *bytes.Buffer, key string, values []string) {
+	quoted := make([]string, len(values))
+	for i, v := range values {
+		quoted[i] = fmt.Sprintf("\"%s\"", v)
+	}
+	buf.WriteString(fmt.Sprintf("%s = [%s]\n", key, strings.Join(quoted, ", ")))
+}
+
+// LoadLockfile decodes selene.lock if present. Missing files are treated as empty lockfiles.
+func LoadLockfile(root string) (*Lockfile, error) {
+	path := filepath.Join(root, LockName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return &Lockfile{}, nil
+		}
+		return nil, err
+	}
+	lock := &Lockfile{}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	current := LockedDependency{}
+	reading := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if line == "[[dependency]]" {
+			if reading {
+				lock.Dependencies = append(lock.Dependencies, current)
+			}
+			current = LockedDependency{}
+			reading = true
+			continue
+		}
+		key, value, ok := splitKeyValue(line)
+		if !ok {
+			continue
+		}
+		parsed, err := parseString(value)
+		if err != nil {
+			return nil, err
+		}
+		switch key {
+		case "module":
+			current.Module = parsed
+		case "version":
+			current.Version = parsed
+		case "checksum":
+			current.Checksum = parsed
+		case "vendor":
+			current.Vendor = parsed
+		}
+	}
+	if reading {
+		lock.Dependencies = append(lock.Dependencies, current)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return lock, nil
+}
+
+// SaveLockfile writes selene.lock to disk.
+func SaveLockfile(root string, lock *Lockfile) error {
+	var buf bytes.Buffer
+	for _, dep := range lock.Dependencies {
+		buf.WriteString("[[dependency]]\n")
+		fmt.Fprintf(&buf, "module = \"%s\"\n", dep.Module)
+		fmt.Fprintf(&buf, "version = \"%s\"\n", dep.Version)
+		fmt.Fprintf(&buf, "checksum = \"%s\"\n", dep.Checksum)
+		fmt.Fprintf(&buf, "vendor = \"%s\"\n\n", dep.Vendor)
+	}
+	path := filepath.Join(root, LockName)
+	return os.WriteFile(path, buf.Bytes(), 0o644)
+}
+
+// Set ensures a dependency entry is updated (or appended) in the lockfile.
+func (l *Lockfile) Set(dep LockedDependency) {
+	for i, existing := range l.Dependencies {
+		if existing.Module == dep.Module {
+			l.Dependencies[i] = dep
+			return
+		}
+	}
+	l.Dependencies = append(l.Dependencies, dep)
+}
+
+// Lookup finds a locked dependency by module path.
+func (l *Lockfile) Lookup(module string) (LockedDependency, bool) {
+	for _, dep := range l.Dependencies {
+		if dep.Module == module {
+			return dep, true
+		}
+	}
+	return LockedDependency{}, false
+}
+
+// VendorPath returns the canonical vendor directory for a module@version pair.
+func VendorPath(module, version string) string {
+	sanitized := strings.ReplaceAll(version, string(filepath.Separator), "_")
+	modulePath := filepath.FromSlash(module + "@" + sanitized)
+	return filepath.Join(VendorDirectory, modulePath)
+}
+
+// SortedModules returns the manifest dependency keys in lexical order.
+func SortedModules(deps map[string]Dependency) []string {
+	modules := make([]string, 0, len(deps))
+	for module := range deps {
+		modules = append(modules, module)
+	}
+	sort.Strings(modules)
+	return modules
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1,0 +1,2400 @@
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"selenelang/internal/ast"
+	"selenelang/internal/lexer"
+	"selenelang/internal/parser"
+	"selenelang/internal/token"
+)
+
+type Value interface {
+	Type() string
+	Inspect() string
+}
+
+var extensionRegistry = make(map[string]map[string]*Function)
+
+func registerExtension(typeName, method string, fn *Function) {
+	name := normalizeTypeName(typeName)
+	if _, ok := extensionRegistry[name]; !ok {
+		extensionRegistry[name] = make(map[string]*Function)
+	}
+	extensionRegistry[name][method] = fn
+}
+
+func lookupExtension(typeName, method string) (*Function, bool) {
+	name := normalizeTypeName(typeName)
+	if methods, ok := extensionRegistry[name]; ok {
+		fn, ok := methods[method]
+		return fn, ok
+	}
+	return nil, false
+}
+
+func normalizeTypeName(name string) string {
+	switch name {
+	case "Int", "Integer", "Float", "Number":
+		return "Number"
+	case "Bool", "Boolean":
+		return "Boolean"
+	case "String":
+		return "String"
+	default:
+		return name
+	}
+}
+
+type Number struct {
+	Value float64
+}
+
+func (n *Number) Type() string    { return "Number" }
+func (n *Number) Inspect() string { return strconv.FormatFloat(n.Value, 'f', -1, 64) }
+
+type String struct {
+	Value string
+}
+
+func (s *String) Type() string    { return "String" }
+func (s *String) Inspect() string { return s.Value }
+
+type Boolean struct {
+	Value bool
+}
+
+func (b *Boolean) Type() string { return "Boolean" }
+func (b *Boolean) Inspect() string {
+	if b.Value {
+		return "true"
+	}
+	return "false"
+}
+
+type Null struct{}
+
+func (n *Null) Type() string    { return "Null" }
+func (n *Null) Inspect() string { return "null" }
+
+var NullValue Value = &Null{}
+var TrueValue Value = &Boolean{Value: true}
+var FalseValue Value = &Boolean{Value: false}
+
+type ErrorValue struct {
+	Message string
+	Cause   Value
+}
+
+func (e *ErrorValue) Type() string { return "Error" }
+func (e *ErrorValue) Inspect() string {
+	if e.Cause != nil {
+		return fmt.Sprintf("<error %s : %s>", e.Message, e.Cause.Inspect())
+	}
+	return fmt.Sprintf("<error %s>", e.Message)
+}
+
+func toErrorValue(val Value) *ErrorValue {
+	switch v := val.(type) {
+	case *ErrorValue:
+		return v
+	case *String:
+		return &ErrorValue{Message: v.Value}
+	default:
+		return &ErrorValue{Message: v.Inspect(), Cause: val}
+	}
+}
+
+type Array struct {
+	Elements []Value
+}
+
+func (a *Array) Type() string { return "Array" }
+func (a *Array) Inspect() string {
+	parts := make([]string, len(a.Elements))
+	for i, el := range a.Elements {
+		parts[i] = el.Inspect()
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+type Object struct {
+	Properties map[string]Value
+}
+
+func (o *Object) Type() string { return "Object" }
+func (o *Object) Inspect() string {
+	parts := make([]string, 0, len(o.Properties))
+	for k, v := range o.Properties {
+		parts = append(parts, fmt.Sprintf("%s: %s", k, v.Inspect()))
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+type Module struct {
+	Name    string
+	Exports map[string]Value
+}
+
+// NewModule constructs a module wrapper with a defensive copy of the provided exports.
+func NewModule(name string, exports map[string]Value) *Module {
+	copy := make(map[string]Value, len(exports))
+	for k, v := range exports {
+		copy[k] = v
+	}
+	return &Module{Name: name, Exports: copy}
+}
+
+func (m *Module) Type() string { return "Module" }
+func (m *Module) Inspect() string {
+	keys := make([]string, 0, len(m.Exports))
+	for k := range m.Exports {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = k
+	}
+	return fmt.Sprintf("<module %s [%s]>", m.Name, strings.Join(parts, ", "))
+}
+
+type StructType struct {
+	Name    string
+	Fields  []string
+	Methods map[string]*Function
+	Static  map[string]Value
+}
+
+func (s *StructType) Type() string { return "Struct" }
+func (s *StructType) Inspect() string {
+	return fmt.Sprintf("<struct %s>", s.Name)
+}
+
+type StructInstance struct {
+	Definition *StructType
+	Fields     map[string]Value
+}
+
+func (s *StructInstance) Type() string { return s.Definition.Name }
+func (s *StructInstance) Inspect() string {
+	keys := make([]string, 0, len(s.Fields))
+	for k := range s.Fields {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = fmt.Sprintf("%s: %s", k, s.Fields[k].Inspect())
+	}
+	return fmt.Sprintf("%s{%s}", s.Definition.Name, strings.Join(parts, ", "))
+}
+
+type ClassType struct {
+	Name    string
+	Fields  []string
+	Methods map[string]*Function
+	Static  map[string]Value
+	Super   *ClassType
+}
+
+func (c *ClassType) Type() string { return "Class" }
+func (c *ClassType) Inspect() string {
+	return fmt.Sprintf("<class %s>", c.Name)
+}
+
+type ClassInstance struct {
+	Definition *ClassType
+	Fields     map[string]Value
+}
+
+func (c *ClassInstance) Type() string { return c.Definition.Name }
+func (c *ClassInstance) Inspect() string {
+	keys := make([]string, 0, len(c.Fields))
+	for k := range c.Fields {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = fmt.Sprintf("%s: %s", k, c.Fields[k].Inspect())
+	}
+	return fmt.Sprintf("%s{%s}", c.Definition.Name, strings.Join(parts, ", "))
+}
+
+func (c *ClassType) lookupMethod(name string) (*Function, bool) {
+	if c == nil {
+		return nil, false
+	}
+	if fn, ok := c.Methods[name]; ok {
+		return fn, true
+	}
+	if c.Super != nil {
+		return c.Super.lookupMethod(name)
+	}
+	return nil, false
+}
+
+func (c *ClassType) lookupStatic(name string) (Value, bool) {
+	if c == nil {
+		return nil, false
+	}
+	if val, ok := c.Static[name]; ok {
+		return val, true
+	}
+	if c.Super != nil {
+		return c.Super.lookupStatic(name)
+	}
+	return nil, false
+}
+
+type EnumType struct {
+	Name         string
+	Cases        map[string][]string
+	Constructors map[string]Value
+}
+
+func (e *EnumType) Type() string { return "Enum" }
+func (e *EnumType) Inspect() string {
+	keys := make([]string, 0, len(e.Cases))
+	for k := range e.Cases {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return fmt.Sprintf("<enum %s [%s]>", e.Name, strings.Join(keys, ", "))
+}
+
+type EnumInstance struct {
+	Enum   *EnumType
+	Case   string
+	Fields map[string]Value
+	Order  []string
+}
+
+func (e *EnumInstance) Type() string { return e.Enum.Name }
+func (e *EnumInstance) Inspect() string {
+	args := make([]string, len(e.Order))
+	for i, name := range e.Order {
+		args[i] = e.Fields[name].Inspect()
+	}
+	if len(args) == 0 {
+		return fmt.Sprintf("%s.%s", e.Enum.Name, e.Case)
+	}
+	return fmt.Sprintf("%s.%s(%s)", e.Enum.Name, e.Case, strings.Join(args, ", "))
+}
+
+type ChannelValue struct {
+	ch       chan Value
+	capacity int
+	closed   bool
+}
+
+func (c *ChannelValue) Type() string { return "Channel" }
+func (c *ChannelValue) Inspect() string {
+	state := "open"
+	if c.closed {
+		state = "closed"
+	}
+	return fmt.Sprintf("<channel %s capacity=%d>", state, c.capacity)
+}
+
+func (c *ChannelValue) send(val Value) error {
+	if c.closed {
+		return errors.New("send on closed channel")
+	}
+	c.ch <- val
+	return nil
+}
+
+func (c *ChannelValue) recv() (Value, error) {
+	v, ok := <-c.ch
+	if !ok {
+		return NullValue, errors.New("receive on closed channel")
+	}
+	return v, nil
+}
+
+func (c *ChannelValue) close() error {
+	if c.closed {
+		return nil
+	}
+	close(c.ch)
+	c.closed = true
+	return nil
+}
+
+type taskResult struct {
+	value Value
+	err   error
+}
+
+type Task struct {
+	once    sync.Once
+	result  taskResult
+	settled bool
+	ch      chan taskResult
+}
+
+func NewTask() *Task {
+	return &Task{ch: make(chan taskResult, 1)}
+}
+
+func (t *Task) Type() string    { return "Task" }
+func (t *Task) Inspect() string { return "<task>" }
+
+func (t *Task) deliver(val Value, err error) {
+	t.ch <- taskResult{value: val, err: err}
+	close(t.ch)
+}
+
+func (t *Task) await() taskResult {
+	t.once.Do(func() {
+		res, ok := <-t.ch
+		if ok {
+			t.result = res
+		} else {
+			t.result = taskResult{value: NullValue, err: nil}
+		}
+		t.settled = true
+	})
+	if !t.settled {
+		res, ok := <-t.ch
+		if ok {
+			t.result = res
+		} else {
+			t.result = taskResult{value: NullValue, err: nil}
+		}
+		t.settled = true
+	}
+	return t.result
+}
+
+func (t *Task) Join() (Value, error) {
+	res := t.await()
+	return res.value, res.err
+}
+
+type Contract struct {
+	Name    string
+	Exports map[string]Value
+}
+
+func (c *Contract) Type() string { return "Contract" }
+func (c *Contract) Inspect() string {
+	keys := make([]string, 0, len(c.Exports))
+	for k := range c.Exports {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return fmt.Sprintf("<contract %s [%s]>", c.Name, strings.Join(keys, ", "))
+}
+
+type InterfaceType struct {
+	Name    string
+	Methods map[string]int
+}
+
+func (i *InterfaceType) Type() string { return "Interface" }
+func (i *InterfaceType) Inspect() string {
+	keys := make([]string, 0, len(i.Methods))
+	for k := range i.Methods {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return fmt.Sprintf("<interface %s [%s]>", i.Name, strings.Join(keys, ", "))
+}
+
+type BuiltinFunction func(args []Value) (Value, error)
+
+type Function struct {
+	Declaration *ast.FunctionDeclaration
+	Env         *Environment
+	Builtin     BuiltinFunction
+	Name        string
+}
+
+func (f *Function) Type() string { return "Function" }
+func (f *Function) Inspect() string {
+	if f.Name != "" {
+		return fmt.Sprintf("<fn %s>", f.Name)
+	}
+	return "<fn>"
+}
+
+func NewBoolean(v bool) Value {
+	if v {
+		return TrueValue
+	}
+	return FalseValue
+}
+
+func NewNumber(v float64) Value { return &Number{Value: v} }
+func NewString(v string) Value  { return &String{Value: v} }
+
+func NewBuiltin(name string, fn BuiltinFunction) Value {
+	return &Function{Name: name, Builtin: fn}
+}
+
+type returnSignal struct {
+	value Value
+}
+
+func (r *returnSignal) Error() string { return "return" }
+
+type breakSignal struct{}
+
+func (b *breakSignal) Error() string { return "break" }
+
+type continueSignal struct{}
+
+func (c *continueSignal) Error() string { return "continue" }
+
+type runtimeError struct {
+	value *ErrorValue
+}
+
+func (r *runtimeError) Error() string { return r.value.Message }
+
+func wrapRuntimeError(err error) *runtimeError {
+	if err == nil {
+		return nil
+	}
+	if rt, ok := err.(*runtimeError); ok {
+		return rt
+	}
+	return &runtimeError{value: &ErrorValue{Message: err.Error()}}
+}
+
+type Environment struct {
+	store map[string]Value
+	outer *Environment
+}
+
+func NewEnvironment() *Environment {
+	return &Environment{store: make(map[string]Value)}
+}
+
+func NewEnclosedEnvironment(outer *Environment) *Environment {
+	env := NewEnvironment()
+	env.outer = outer
+	return env
+}
+
+func (e *Environment) Get(name string) (Value, bool) {
+	if val, ok := e.store[name]; ok {
+		return val, true
+	}
+	if e.outer != nil {
+		return e.outer.Get(name)
+	}
+	return nil, false
+}
+
+func (e *Environment) Set(name string, val Value) Value {
+	e.store[name] = val
+	return val
+}
+
+// Snapshot returns a shallow copy of the bindings stored in the environment.
+func (e *Environment) Snapshot() map[string]Value {
+	out := make(map[string]Value, len(e.store))
+	for k, v := range e.store {
+		out[k] = v
+	}
+	return out
+}
+
+func (e *Environment) Assign(name string, val Value) (Value, error) {
+	if _, ok := e.store[name]; ok {
+		e.store[name] = val
+		return val, nil
+	}
+	if e.outer != nil {
+		return e.outer.Assign(name, val)
+	}
+	return nil, fmt.Errorf("undefined variable %s", name)
+}
+
+func (e *Environment) resolve(name string) (*Environment, bool) {
+	if _, ok := e.store[name]; ok {
+		return e, true
+	}
+	if e.outer != nil {
+		return e.outer.resolve(name)
+	}
+	return nil, false
+}
+
+type Pointer struct {
+	env  *Environment
+	name string
+}
+
+func (p *Pointer) Type() string    { return "Pointer" }
+func (p *Pointer) Inspect() string { return fmt.Sprintf("&%s", p.name) }
+
+func (p *Pointer) get() (Value, error) {
+	if p == nil || p.env == nil {
+		return nil, errors.New("dereference of nil pointer")
+	}
+	if val, ok := p.env.store[p.name]; ok {
+		return val, nil
+	}
+	return nil, fmt.Errorf("dangling pointer to %s", p.name)
+}
+
+func (p *Pointer) set(val Value) error {
+	if p == nil || p.env == nil {
+		return errors.New("assignment to nil pointer")
+	}
+	if _, ok := p.env.store[p.name]; !ok {
+		return fmt.Errorf("dangling pointer to %s", p.name)
+	}
+	p.env.store[p.name] = val
+	return nil
+}
+
+type Runtime struct {
+	env *Environment
+}
+
+func New() *Runtime {
+	env := NewEnvironment()
+	env.Set("print", NewBuiltin("print", builtinPrint))
+	env.Set("format", NewBuiltin("format", builtinFormat))
+	env.Set("spawn", NewBuiltin("spawn", builtinSpawn))
+	env.Set("channel", NewBuiltin("channel", builtinChannel))
+	return &Runtime{env: env}
+}
+
+func (r *Runtime) Environment() *Environment {
+	return r.env
+}
+
+func (r *Runtime) Run(program *ast.Program) (Value, error) {
+	return evalProgram(program, r.env)
+}
+
+func evalProgram(program *ast.Program, env *Environment) (Value, error) {
+	result := NullValue
+	for _, item := range program.Items {
+		switch node := item.(type) {
+		case ast.Statement:
+			val, err := evalStatement(node, env)
+			if err != nil {
+				if _, ok := err.(*returnSignal); ok {
+					return nil, errors.New("return outside of function")
+				}
+				if _, ok := err.(*breakSignal); ok {
+					return nil, errors.New("break outside of loop")
+				}
+				if _, ok := err.(*continueSignal); ok {
+					return nil, errors.New("continue outside of loop")
+				}
+				return nil, err
+			}
+			result = val
+		case *ast.ModuleDeclaration:
+			val, err := evalModuleDeclaration(node, env)
+			if err != nil {
+				return nil, err
+			}
+			result = val
+		case *ast.PackageDeclaration:
+			if node.Name != nil {
+				env.Set("__package__", NewString(node.Name.Name))
+			}
+			result = NullValue
+		default:
+			return nil, fmt.Errorf("runtime does not support top-level %T", item)
+		}
+	}
+	return result, nil
+}
+
+func evalStatement(stmt ast.Statement, env *Environment) (Value, error) {
+	switch node := stmt.(type) {
+	case *ast.ExpressionStatement:
+		if node.Expression == nil {
+			return NullValue, nil
+		}
+		return evalExpression(node.Expression, env)
+	case *ast.VariableDeclaration:
+		var val Value = NullValue
+		var err error
+		if node.Value != nil {
+			val, err = evalExpression(node.Value, env)
+			if err != nil {
+				return nil, err
+			}
+		}
+		env.Set(node.Name.Name, val)
+		return val, nil
+	case *ast.FunctionDeclaration:
+		fn := &Function{Declaration: node, Env: env, Name: node.Name.Name}
+		if node.IsExtension {
+			if node.Receiver == nil || node.Receiver.Name == nil {
+				return nil, errors.New("extension function requires receiver type")
+			}
+			registerExtension(node.Receiver.Name.Name, node.Name.Name, fn)
+			return fn, nil
+		}
+		env.Set(node.Name.Name, fn)
+		return fn, nil
+	case *ast.InterfaceDeclaration:
+		methods := make(map[string]int)
+		for _, method := range node.Methods {
+			if method.Name != nil {
+				methods[method.Name.Name] = len(method.Params)
+			}
+		}
+		iface := &InterfaceType{Name: node.Name.Name, Methods: methods}
+		env.Set(node.Name.Name, iface)
+		return iface, nil
+	case *ast.ImportDeclaration:
+		return evalImportDeclaration(node, env)
+	case *ast.StructDeclaration:
+		return evalStructDeclaration(node, env)
+	case *ast.ClassDeclaration:
+		return evalClassDeclaration(node, env)
+	case *ast.EnumDeclaration:
+		return evalEnumDeclaration(node, env)
+	case *ast.ContractDeclaration:
+		return evalContractDeclaration(node, env)
+	case *ast.BlockStatement:
+		blockEnv := NewEnclosedEnvironment(env)
+		return evalBlock(node, blockEnv)
+	case *ast.MatchStatement:
+		return evalMatchStatement(node, env)
+	case *ast.IfStatement:
+		return evalIfStatement(node, env)
+	case *ast.WhileStatement:
+		return evalWhileStatement(node, env)
+	case *ast.ForStatement:
+		return evalForStatement(node, env)
+	case *ast.UsingStatement:
+		return evalUsingStatement(node, env)
+	case *ast.TryStatement:
+		return evalTryStatement(node, env)
+	case *ast.ThrowStatement:
+		val, err := evalExpression(node.Value, env)
+		if err != nil {
+			return nil, err
+		}
+		return NullValue, &runtimeError{value: toErrorValue(val)}
+	case *ast.ConditionStatement:
+		return evalConditionStatement(node, env)
+	case *ast.ReturnStatement:
+		var val Value = NullValue
+		var err error
+		if node.Value != nil {
+			val, err = evalExpression(node.Value, env)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return val, &returnSignal{value: val}
+	case *ast.BreakStatement:
+		return NullValue, &breakSignal{}
+	case *ast.ContinueStatement:
+		return NullValue, &continueSignal{}
+	default:
+		return nil, fmt.Errorf("runtime does not support statement %T", stmt)
+	}
+}
+
+func evalBlock(block *ast.BlockStatement, env *Environment) (Value, error) {
+	result := NullValue
+	for _, stmt := range block.Statements {
+		val, err := evalStatement(stmt, env)
+		if err != nil {
+			switch sig := err.(type) {
+			case *returnSignal:
+				return sig.value, err
+			case *breakSignal, *continueSignal:
+				return NullValue, err
+			default:
+				return nil, err
+			}
+		}
+		result = val
+	}
+	return result, nil
+}
+
+func evalIfStatement(stmt *ast.IfStatement, env *Environment) (Value, error) {
+	if stmt.Condition == nil {
+		return NullValue, nil
+	}
+	condition, err := evalExpression(stmt.Condition, env)
+	if err != nil {
+		return nil, err
+	}
+	if isTruthy(condition) {
+		if stmt.Consequence == nil {
+			return NullValue, nil
+		}
+		return evalStatement(stmt.Consequence, env)
+	}
+	if stmt.Alternative != nil {
+		return evalStatement(stmt.Alternative, env)
+	}
+	return NullValue, nil
+}
+
+func evalWhileStatement(stmt *ast.WhileStatement, env *Environment) (Value, error) {
+	result := NullValue
+	for {
+		if stmt.Condition != nil {
+			cond, err := evalExpression(stmt.Condition, env)
+			if err != nil {
+				return nil, err
+			}
+			if !isTruthy(cond) {
+				break
+			}
+		}
+		if stmt.Body == nil {
+			continue
+		}
+		val, err := evalStatement(stmt.Body, env)
+		if err != nil {
+			switch sig := err.(type) {
+			case *breakSignal:
+				return result, nil
+			case *continueSignal:
+				continue
+			case *returnSignal:
+				return sig.value, err
+			default:
+				return nil, err
+			}
+		}
+		result = val
+	}
+	return result, nil
+}
+
+func evalForStatement(stmt *ast.ForStatement, env *Environment) (Value, error) {
+	loopEnv := NewEnclosedEnvironment(env)
+	if stmt.Init != nil {
+		if _, err := evalStatement(stmt.Init, loopEnv); err != nil {
+			switch err.(type) {
+			case *returnSignal:
+				return nil, errors.New("return not allowed in for initializer")
+			case *breakSignal, *continueSignal:
+				return nil, errors.New("loop control not allowed in for initializer")
+			default:
+				return nil, err
+			}
+		}
+	}
+
+	result := NullValue
+	for {
+		if stmt.Condition != nil {
+			cond, err := evalExpression(stmt.Condition, loopEnv)
+			if err != nil {
+				return nil, err
+			}
+			if !isTruthy(cond) {
+				break
+			}
+		}
+
+		if stmt.Body != nil {
+			val, err := evalStatement(stmt.Body, loopEnv)
+			if err != nil {
+				switch sig := err.(type) {
+				case *breakSignal:
+					return result, nil
+				case *continueSignal:
+					if stmt.Post != nil {
+						if _, err := evalExpression(stmt.Post, loopEnv); err != nil {
+							return nil, err
+						}
+					}
+					continue
+				case *returnSignal:
+					return sig.value, err
+				default:
+					return nil, err
+				}
+			} else {
+				result = val
+			}
+		}
+
+		if stmt.Post != nil {
+			if _, err := evalExpression(stmt.Post, loopEnv); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func evalExpression(expr ast.Expression, env *Environment) (Value, error) {
+	switch node := expr.(type) {
+	case *ast.Identifier:
+		if val, ok := env.Get(node.Name); ok {
+			return val, nil
+		}
+		return nil, fmt.Errorf("undefined identifier %s", node.Name)
+	case *ast.NumberLiteral:
+		num, err := strconv.ParseFloat(node.Value, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid number literal %q", node.Value)
+		}
+		return NewNumber(num), nil
+	case *ast.StringLiteral:
+		return renderStringLiteral(node, env)
+	case *ast.BooleanLiteral:
+		return NewBoolean(node.Value), nil
+	case *ast.NullLiteral:
+		return NullValue, nil
+	case *ast.AwaitExpression:
+		val, err := evalExpression(node.Expression, env)
+		if err != nil {
+			return nil, err
+		}
+		switch async := val.(type) {
+		case *Task:
+			return async.Join()
+		case *ChannelValue:
+			return async.recv()
+		default:
+			return val, nil
+		}
+	case *ast.PrefixExpression:
+		if node.Operator == "&" {
+			ident, ok := node.Right.(*ast.Identifier)
+			if !ok {
+				return nil, errors.New("address-of operator requires identifier")
+			}
+			targetEnv, ok := env.resolve(ident.Name)
+			if !ok {
+				return nil, fmt.Errorf("undefined identifier %s", ident.Name)
+			}
+			return &Pointer{env: targetEnv, name: ident.Name}, nil
+		}
+		if node.Operator == "*" {
+			ptrVal, err := evalExpression(node.Right, env)
+			if err != nil {
+				return nil, err
+			}
+			pointer, ok := ptrVal.(*Pointer)
+			if !ok {
+				return nil, fmt.Errorf("cannot dereference %s", ptrVal.Type())
+			}
+			return pointer.get()
+		}
+		right, err := evalExpression(node.Right, env)
+		if err != nil {
+			return nil, err
+		}
+		return evalPrefixExpression(node.Operator, right)
+	case *ast.InfixExpression:
+		left, err := evalExpression(node.Left, env)
+		if err != nil {
+			return nil, err
+		}
+		right, err := evalExpression(node.Right, env)
+		if err != nil {
+			return nil, err
+		}
+		return evalInfixExpression(node.Operator, left, right)
+	case *ast.AssignmentExpression:
+		switch target := node.Target.(type) {
+		case *ast.Identifier:
+			right, err := evalExpression(node.Value, env)
+			if err != nil {
+				return nil, err
+			}
+			var result Value
+			if node.Operator == token.ASSIGN {
+				result = right
+			} else {
+				current, ok := env.Get(target.Name)
+				if !ok {
+					return nil, fmt.Errorf("undefined variable %s", target.Name)
+				}
+				result, err = applyAugmentedAssignment(node.Operator, current, right)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if _, err := env.Assign(target.Name, result); err != nil {
+				return nil, err
+			}
+			return result, nil
+		case *ast.PrefixExpression:
+			if target.Operator != "*" {
+				return nil, errors.New("unsupported assignment target")
+			}
+			ptrRef, err := evalExpression(target.Right, env)
+			if err != nil {
+				return nil, err
+			}
+			pointer, ok := ptrRef.(*Pointer)
+			if !ok {
+				return nil, errors.New("assignment target is not a pointer")
+			}
+			value, err := evalExpression(node.Value, env)
+			if err != nil {
+				return nil, err
+			}
+			result := value
+			if node.Operator != token.ASSIGN {
+				current, err := pointer.get()
+				if err != nil {
+					return nil, err
+				}
+				result, err = applyAugmentedAssignment(node.Operator, current, value)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if err := pointer.set(result); err != nil {
+				return nil, err
+			}
+			return result, nil
+		default:
+			return nil, errors.New("unsupported assignment target")
+		}
+	case *ast.CallExpression:
+		callee, err := evalExpression(node.Callee, env)
+		if err != nil {
+			return nil, err
+		}
+		args := make([]Value, 0, len(node.Arguments))
+		for _, arg := range node.Arguments {
+			val, err := evalExpression(arg, env)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, val)
+		}
+		return applyFunction(callee, args)
+	case *ast.ArrayLiteral:
+		elements := make([]Value, 0, len(node.Elements))
+		for _, el := range node.Elements {
+			val, err := evalExpression(el, env)
+			if err != nil {
+				return nil, err
+			}
+			elements = append(elements, val)
+		}
+		return &Array{Elements: elements}, nil
+	case *ast.ObjectLiteral:
+		props := make(map[string]Value)
+		for _, pair := range node.Pairs {
+			val, err := evalExpression(pair.Value, env)
+			if err != nil {
+				return nil, err
+			}
+			props[pair.Key] = val
+		}
+		return &Object{Properties: props}, nil
+	case *ast.IndexExpression:
+		collection, err := evalExpression(node.Collection, env)
+		if err != nil {
+			return nil, err
+		}
+		indexVal, err := evalExpression(node.Index, env)
+		if err != nil {
+			return nil, err
+		}
+		return evalIndexExpression(collection, indexVal)
+	case *ast.MemberExpression:
+		objectVal, err := evalExpression(node.Object, env)
+		if err != nil {
+			return nil, err
+		}
+		return evalMemberExpression(objectVal, node.Property, node.Optional)
+	case *ast.ElvisExpression:
+		left, err := evalExpression(node.Left, env)
+		if err != nil {
+			return nil, err
+		}
+		if isTruthy(left) {
+			return left, nil
+		}
+		return evalExpression(node.Right, env)
+	case *ast.NonNullAssertion:
+		val, err := evalExpression(node.Expression, env)
+		if err != nil {
+			return nil, err
+		}
+		if _, isNull := val.(*Null); isNull {
+			return nil, errors.New("encountered null in non-null assertion")
+		}
+		return val, nil
+	default:
+		return nil, fmt.Errorf("runtime does not support expression %T", expr)
+	}
+}
+
+func evalPrefixExpression(operator string, right Value) (Value, error) {
+	switch operator {
+	case "!":
+		return NewBoolean(!isTruthy(right)), nil
+	case "-":
+		number, ok := right.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("cannot negate %s", right.Type())
+		}
+		return NewNumber(-number.Value), nil
+	case "+":
+		if number, ok := right.(*Number); ok {
+			return NewNumber(+number.Value), nil
+		}
+		return nil, fmt.Errorf("cannot apply unary + to %s", right.Type())
+	default:
+		return nil, fmt.Errorf("unknown prefix operator %s", operator)
+	}
+}
+
+func evalInfixExpression(operator string, left, right Value) (Value, error) {
+	switch operator {
+	case "+":
+		switch l := left.(type) {
+		case *Number:
+			r, ok := right.(*Number)
+			if !ok {
+				return nil, fmt.Errorf("cannot add %s to Number", right.Type())
+			}
+			return NewNumber(l.Value + r.Value), nil
+		case *String:
+			return NewString(l.Value + toString(right)), nil
+		default:
+			if _, ok := right.(*String); ok {
+				return NewString(toString(left) + toString(right)), nil
+			}
+			return nil, fmt.Errorf("operator + not supported for %s", left.Type())
+		}
+	case "-":
+		l, ok := left.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("operator - not supported for %s", left.Type())
+		}
+		r, ok := right.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("operator - requires Number on right, got %s", right.Type())
+		}
+		return NewNumber(l.Value - r.Value), nil
+	case "*":
+		l, ok := left.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("operator * not supported for %s", left.Type())
+		}
+		r, ok := right.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("operator * requires Number on right, got %s", right.Type())
+		}
+		return NewNumber(l.Value * r.Value), nil
+	case "/":
+		l, ok := left.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("operator / not supported for %s", left.Type())
+		}
+		r, ok := right.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("operator / requires Number on right, got %s", right.Type())
+		}
+		if r.Value == 0 {
+			return nil, errors.New("division by zero")
+		}
+		return NewNumber(l.Value / r.Value), nil
+	case "%":
+		l, ok := left.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("operator %% not supported for %s", left.Type())
+		}
+		r, ok := right.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("operator %% requires Number on right, got %s", right.Type())
+		}
+		if r.Value == 0 {
+			return nil, errors.New("modulo by zero")
+		}
+		return NewNumber(math.Mod(l.Value, r.Value)), nil
+	case "==":
+		return NewBoolean(equals(left, right)), nil
+	case "!=":
+		return NewBoolean(!equals(left, right)), nil
+	case "<":
+		return compareNumbers(operator, left, right)
+	case "<=":
+		return compareNumbers(operator, left, right)
+	case ">":
+		return compareNumbers(operator, left, right)
+	case ">=":
+		return compareNumbers(operator, left, right)
+	case "&&":
+		return NewBoolean(isTruthy(left) && isTruthy(right)), nil
+	case "||":
+		return NewBoolean(isTruthy(left) || isTruthy(right)), nil
+	case "is":
+		return evalIsOperator(left, right)
+	case "!is":
+		result, err := evalIsOperator(left, right)
+		if err != nil {
+			return nil, err
+		}
+		boolVal, ok := result.(*Boolean)
+		if !ok {
+			return nil, errors.New("operator is must return Boolean")
+		}
+		return NewBoolean(!boolVal.Value), nil
+	default:
+		return nil, fmt.Errorf("unknown infix operator %s", operator)
+	}
+}
+
+func applyAugmentedAssignment(op token.Type, current, update Value) (Value, error) {
+	switch op {
+	case token.PLUS_ASSIGN:
+		return evalInfixExpression("+", current, update)
+	case token.MINUS_ASSIGN:
+		return evalInfixExpression("-", current, update)
+	case token.STAR_ASSIGN:
+		return evalInfixExpression("*", current, update)
+	case token.SLASH_ASSIGN:
+		return evalInfixExpression("/", current, update)
+	case token.PERCENT_ASSIGN:
+		return evalInfixExpression("%", current, update)
+	default:
+		return nil, fmt.Errorf("unsupported assignment operator %s", op)
+	}
+}
+
+func compareNumbers(operator string, left, right Value) (Value, error) {
+	l, ok := left.(*Number)
+	if !ok {
+		return nil, fmt.Errorf("operator %s requires Number operands", operator)
+	}
+	r, ok := right.(*Number)
+	if !ok {
+		return nil, fmt.Errorf("operator %s requires Number operands", operator)
+	}
+
+	switch operator {
+	case "<":
+		return NewBoolean(l.Value < r.Value), nil
+	case "<=":
+		return NewBoolean(l.Value <= r.Value), nil
+	case ">":
+		return NewBoolean(l.Value > r.Value), nil
+	case ">=":
+		return NewBoolean(l.Value >= r.Value), nil
+	default:
+		return nil, fmt.Errorf("unknown comparison operator %s", operator)
+	}
+}
+
+func equals(left, right Value) bool {
+	switch l := left.(type) {
+	case *Null:
+		_, isNull := right.(*Null)
+		return isNull
+	case *Boolean:
+		r, ok := right.(*Boolean)
+		return ok && l.Value == r.Value
+	case *Number:
+		r, ok := right.(*Number)
+		return ok && l.Value == r.Value
+	case *String:
+		r, ok := right.(*String)
+		return ok && l.Value == r.Value
+	default:
+		return left == right
+	}
+}
+
+func toString(val Value) string {
+	return val.Inspect()
+}
+
+func isTruthy(val Value) bool {
+	switch v := val.(type) {
+	case *Null:
+		return false
+	case *Boolean:
+		return v.Value
+	case *Number:
+		return v.Value != 0
+	case *String:
+		return v.Value != ""
+	case *Array:
+		return len(v.Elements) > 0
+	case *Object:
+		return len(v.Properties) > 0
+	default:
+		return val != nil
+	}
+}
+
+func evalIndexExpression(collection, index Value) (Value, error) {
+	switch col := collection.(type) {
+	case *Array:
+		num, ok := index.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("array index must be Number, got %s", index.Type())
+		}
+		idx := int(num.Value)
+		if float64(idx) != num.Value {
+			return nil, errors.New("array index must be integer")
+		}
+		if idx < 0 || idx >= len(col.Elements) {
+			return nil, fmt.Errorf("array index %d out of range", idx)
+		}
+		return col.Elements[idx], nil
+	case *String:
+		num, ok := index.(*Number)
+		if !ok {
+			return nil, fmt.Errorf("string index must be Number, got %s", index.Type())
+		}
+		idx := int(num.Value)
+		if float64(idx) != num.Value {
+			return nil, errors.New("string index must be integer")
+		}
+		runes := []rune(col.Value)
+		if idx < 0 || idx >= len(runes) {
+			return nil, fmt.Errorf("string index %d out of range", idx)
+		}
+		return NewString(string(runes[idx])), nil
+	default:
+		return nil, fmt.Errorf("cannot index into %s", collection.Type())
+	}
+}
+
+func evalMemberExpression(object Value, property string, optional bool) (Value, error) {
+	val, ok, err := getProperty(object, property)
+	if err != nil {
+		if optional {
+			return NullValue, nil
+		}
+		return nil, err
+	}
+	if !ok {
+		if optional {
+			return NullValue, nil
+		}
+		return nil, fmt.Errorf("%s has no property %s", object.Type(), property)
+	}
+	return val, nil
+}
+
+func evalMatchStatement(match *ast.MatchStatement, env *Environment) (Value, error) {
+	target, err := evalExpression(match.Value, env)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, clause := range match.Cases {
+		caseEnv := NewEnclosedEnvironment(env)
+		matched, err := matchPattern(clause.Pattern, target, caseEnv)
+		if err != nil {
+			return nil, err
+		}
+		if !matched {
+			continue
+		}
+		if clause.Body == nil {
+			return NullValue, nil
+		}
+		return evalStatement(clause.Body, caseEnv)
+	}
+
+	return NullValue, nil
+}
+
+func matchPattern(pattern ast.Pattern, value Value, env *Environment) (bool, error) {
+	switch p := pattern.(type) {
+	case *ast.IdentifierPattern:
+		if p.Identifier == nil {
+			return false, nil
+		}
+		env.Set(p.Identifier.Name, value)
+		return true, nil
+	case *ast.LiteralPattern:
+		expected, err := evalExpression(p.Value, env)
+		if err != nil {
+			return false, err
+		}
+		return equals(expected, value), nil
+	case *ast.ObjectPattern:
+		obj, ok := value.(*Object)
+		if !ok {
+			return false, nil
+		}
+		return matchObjectPattern(p, obj, env)
+	case *ast.StructPattern:
+		return matchStructPatternRuntime(p, value, env)
+	default:
+		return false, fmt.Errorf("unsupported pattern %T", pattern)
+	}
+}
+
+func matchObjectPattern(pattern *ast.ObjectPattern, value *Object, env *Environment) (bool, error) {
+	for _, pair := range pattern.Pairs {
+		propName := pair.Key
+		if pair.KeyIsIdentifier {
+			propName = pair.Key
+		}
+		propVal, ok := value.Properties[propName]
+		if !ok {
+			return false, nil
+		}
+
+		matched, err := matchPattern(pair.Value, propVal, env)
+		if err != nil {
+			return false, err
+		}
+		if !matched {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func matchStructPatternRuntime(pattern *ast.StructPattern, value Value, env *Environment) (bool, error) {
+	if pattern.Name == nil {
+		return false, nil
+	}
+	switch v := value.(type) {
+	case *StructInstance:
+		if v.Definition == nil || v.Definition.Name != pattern.Name.Name {
+			return false, nil
+		}
+		return matchStructFields(pattern.Fields, v.Definition.Fields, v.Fields, env)
+	case *ClassInstance:
+		if v.Definition == nil || v.Definition.Name != pattern.Name.Name {
+			return false, nil
+		}
+		return matchStructFields(pattern.Fields, v.Definition.Fields, v.Fields, env)
+	case *EnumInstance:
+		if v.Case != pattern.Name.Name {
+			return false, nil
+		}
+		return matchEnumFields(pattern.Fields, v, env)
+	default:
+		return false, nil
+	}
+}
+
+func matchStructFields(patterns []ast.Pattern, names []string, fields map[string]Value, env *Environment) (bool, error) {
+	if len(patterns) != len(names) {
+		return false, nil
+	}
+	for i, pat := range patterns {
+		name := names[i]
+		val, ok := fields[name]
+		if !ok {
+			return false, nil
+		}
+		matched, err := matchPattern(pat, val, env)
+		if err != nil {
+			return false, err
+		}
+		if !matched {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func matchEnumFields(patterns []ast.Pattern, instance *EnumInstance, env *Environment) (bool, error) {
+	if len(patterns) != len(instance.Order) {
+		return false, nil
+	}
+	for i, pat := range patterns {
+		name := instance.Order[i]
+		val := instance.Fields[name]
+		matched, err := matchPattern(pat, val, env)
+		if err != nil {
+			return false, err
+		}
+		if !matched {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func getProperty(object Value, property string) (Value, bool, error) {
+	switch obj := object.(type) {
+	case *Object:
+		val, ok := obj.Properties[property]
+		return val, ok, nil
+	case *Module:
+		val, ok := obj.Exports[property]
+		return val, ok, nil
+	case *Contract:
+		val, ok := obj.Exports[property]
+		return val, ok, nil
+	case *Array:
+		if property == "length" {
+			return NewNumber(float64(len(obj.Elements))), true, nil
+		}
+		if fn, ok := lookupExtension(obj.Type(), property); ok {
+			return bindMethod(fn, obj), true, nil
+		}
+		return nil, false, fmt.Errorf("unknown array property %s", property)
+	case *String:
+		if property == "length" {
+			return NewNumber(float64(len(obj.Value))), true, nil
+		}
+		if fn, ok := lookupExtension(obj.Type(), property); ok {
+			return bindMethod(fn, obj), true, nil
+		}
+		return nil, false, fmt.Errorf("unknown string property %s", property)
+	case *StructInstance:
+		if val, ok := obj.Fields[property]; ok {
+			return val, true, nil
+		}
+		if obj.Definition != nil {
+			if method, ok := obj.Definition.Methods[property]; ok {
+				return bindMethod(method, obj), true, nil
+			}
+			if val, ok := obj.Definition.Static[property]; ok {
+				return val, true, nil
+			}
+		}
+		return nil, false, nil
+	case *StructType:
+		if val, ok := obj.Static[property]; ok {
+			return val, true, nil
+		}
+		if method, ok := obj.Methods[property]; ok {
+			return method, true, nil
+		}
+		return nil, false, nil
+	case *ClassInstance:
+		if val, ok := obj.Fields[property]; ok {
+			return val, true, nil
+		}
+		if method, ok := obj.Definition.lookupMethod(property); ok {
+			return bindMethod(method, obj), true, nil
+		}
+		if val, ok := obj.Definition.lookupStatic(property); ok {
+			return val, true, nil
+		}
+		return nil, false, nil
+	case *ClassType:
+		if val, ok := obj.lookupStatic(property); ok {
+			return val, true, nil
+		}
+		if method, ok := obj.lookupMethod(property); ok {
+			return method, true, nil
+		}
+		return nil, false, nil
+	case *EnumType:
+		val, ok := obj.Constructors[property]
+		return val, ok, nil
+	case *EnumInstance:
+		if property == "case" {
+			return NewString(obj.Case), true, nil
+		}
+		val, ok := obj.Fields[property]
+		return val, ok, nil
+	case *ChannelValue:
+		switch property {
+		case "send":
+			return NewBuiltin("send", func(args []Value) (Value, error) {
+				if len(args) != 1 {
+					return nil, errors.New("send expects a single argument")
+				}
+				if err := obj.send(args[0]); err != nil {
+					return nil, err
+				}
+				return NullValue, nil
+			}), true, nil
+		case "recv":
+			return NewBuiltin("recv", func(args []Value) (Value, error) {
+				if len(args) != 0 {
+					return nil, errors.New("recv takes no arguments")
+				}
+				return obj.recv()
+			}), true, nil
+		case "close":
+			return NewBuiltin("close", func(args []Value) (Value, error) {
+				if len(args) != 0 {
+					return nil, errors.New("close takes no arguments")
+				}
+				if err := obj.close(); err != nil {
+					return nil, err
+				}
+				return NullValue, nil
+			}), true, nil
+		default:
+			return nil, false, fmt.Errorf("unknown channel property %s", property)
+		}
+	case *Task:
+		if property == "join" {
+			return NewBuiltin("join", func(args []Value) (Value, error) {
+				if len(args) != 0 {
+					return nil, errors.New("join takes no arguments")
+				}
+				return obj.Join()
+			}), true, nil
+		}
+		return nil, false, fmt.Errorf("unknown task property %s", property)
+	default:
+		if fn, ok := lookupExtension(object.Type(), property); ok {
+			return bindMethod(fn, object), true, nil
+		}
+		return nil, false, fmt.Errorf("cannot access property %s on %s", property, object.Type())
+	}
+}
+
+func bindMethod(fn *Function, self Value) Value {
+	if fn == nil {
+		return NullValue
+	}
+	if fn.Builtin != nil {
+		return NewBuiltin(fn.Name, func(args []Value) (Value, error) {
+			allArgs := append([]Value{self}, args...)
+			return fn.Builtin(allArgs)
+		})
+	}
+	boundEnv := NewEnclosedEnvironment(fn.Env)
+	boundEnv.Set("self", self)
+	boundEnv.Set("this", self)
+	return &Function{Declaration: fn.Declaration, Env: boundEnv, Name: fn.Name}
+}
+
+func cloneStore(store map[string]Value) map[string]Value {
+	out := make(map[string]Value, len(store))
+	for k, v := range store {
+		out[k] = v
+	}
+	return out
+}
+
+func evalModuleDeclaration(module *ast.ModuleDeclaration, env *Environment) (Value, error) {
+	if module.Name == nil {
+		return nil, errors.New("module declaration requires a name")
+	}
+	moduleEnv := NewEnclosedEnvironment(env)
+	if module.Body != nil {
+		if _, err := evalBlock(module.Body, moduleEnv); err != nil {
+			switch err.(type) {
+			case *returnSignal:
+				return nil, errors.New("return not allowed in module body")
+			case *breakSignal, *continueSignal:
+				return nil, errors.New("loop control not allowed in module body")
+			default:
+				return nil, err
+			}
+		}
+	}
+	exports := cloneStore(moduleEnv.store)
+	moduleVal := &Module{Name: module.Name.Name, Exports: exports}
+	env.Set(module.Name.Name, moduleVal)
+	return moduleVal, nil
+}
+
+func evalImportDeclaration(imp *ast.ImportDeclaration, env *Environment) (Value, error) {
+	if len(imp.Path) == 0 {
+		return nil, errors.New("import path cannot be empty")
+	}
+	val, err := resolveImportPath(imp.Path, env)
+	if err != nil {
+		return nil, err
+	}
+	name := imp.Path[len(imp.Path)-1].Name
+	if imp.Alias != nil {
+		name = imp.Alias.Name
+	}
+	env.Set(name, val)
+	return val, nil
+}
+
+func resolveImportPath(path []*ast.Identifier, env *Environment) (Value, error) {
+	var current Value
+	var ok bool
+	for i, segment := range path {
+		if i == 0 {
+			current, ok = env.Get(segment.Name)
+			if !ok {
+				return nil, fmt.Errorf("unknown import %s", segment.Name)
+			}
+			continue
+		}
+		val, found, err := getProperty(current, segment.Name)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			return nil, fmt.Errorf("%s has no property %s", current.Type(), segment.Name)
+		}
+		current = val
+	}
+	return current, nil
+}
+
+func evalStructDeclaration(decl *ast.StructDeclaration, env *Environment) (Value, error) {
+	if decl.Name == nil {
+		return nil, errors.New("struct declaration requires a name")
+	}
+	structType := &StructType{
+		Name:    decl.Name.Name,
+		Fields:  make([]string, 0, len(decl.Params)),
+		Methods: make(map[string]*Function),
+		Static:  make(map[string]Value),
+	}
+	for _, param := range decl.Params {
+		if param.Name != nil {
+			structType.Fields = append(structType.Fields, param.Name.Name)
+		}
+	}
+	bodyEnv := NewEnclosedEnvironment(env)
+	if decl.Body != nil {
+		if _, err := evalBlock(decl.Body, bodyEnv); err != nil {
+			switch err.(type) {
+			case *returnSignal:
+				return nil, errors.New("return not allowed in struct body")
+			case *breakSignal, *continueSignal:
+				return nil, errors.New("loop control not allowed in struct body")
+			default:
+				return nil, err
+			}
+		}
+	}
+	for name, val := range bodyEnv.store {
+		switch v := val.(type) {
+		case *Function:
+			structType.Methods[name] = v
+		default:
+			structType.Static[name] = v
+		}
+	}
+	env.Set(structType.Name, structType)
+	return structType, nil
+}
+
+func evalClassDeclaration(decl *ast.ClassDeclaration, env *Environment) (Value, error) {
+	if decl.Name == nil {
+		return nil, errors.New("class declaration requires a name")
+	}
+	classType := &ClassType{
+		Name:    decl.Name.Name,
+		Fields:  make([]string, 0, len(decl.Params)),
+		Methods: make(map[string]*Function),
+		Static:  make(map[string]Value),
+	}
+	for _, param := range decl.Params {
+		if param.Name != nil {
+			classType.Fields = append(classType.Fields, param.Name.Name)
+		}
+	}
+	if decl.SuperClass != nil {
+		superVal, ok := env.Get(decl.SuperClass.Name)
+		if !ok {
+			return nil, fmt.Errorf("unknown superclass %s", decl.SuperClass.Name)
+		}
+		superType, ok := superVal.(*ClassType)
+		if !ok {
+			return nil, fmt.Errorf("%s is not a class", decl.SuperClass.Name)
+		}
+		classType.Super = superType
+		for name, method := range superType.Methods {
+			classType.Methods[name] = method
+		}
+		for name, val := range superType.Static {
+			classType.Static[name] = val
+		}
+	}
+
+	bodyEnv := NewEnclosedEnvironment(env)
+	if decl.Body != nil {
+		if _, err := evalBlock(decl.Body, bodyEnv); err != nil {
+			switch err.(type) {
+			case *returnSignal:
+				return nil, errors.New("return not allowed in class body")
+			case *breakSignal, *continueSignal:
+				return nil, errors.New("loop control not allowed in class body")
+			default:
+				return nil, err
+			}
+		}
+	}
+	for name, val := range bodyEnv.store {
+		switch v := val.(type) {
+		case *Function:
+			classType.Methods[name] = v
+		default:
+			classType.Static[name] = v
+		}
+	}
+	env.Set(classType.Name, classType)
+	return classType, nil
+}
+
+func evalEnumDeclaration(decl *ast.EnumDeclaration, env *Environment) (Value, error) {
+	if decl.Name == nil {
+		return nil, errors.New("enum declaration requires a name")
+	}
+	enumType := &EnumType{
+		Name:         decl.Name.Name,
+		Cases:        make(map[string][]string),
+		Constructors: make(map[string]Value),
+	}
+	for _, c := range decl.Cases {
+		if c.Name == nil {
+			continue
+		}
+		params := make([]string, 0, len(c.Params))
+		for _, p := range c.Params {
+			if p.Name != nil {
+				params = append(params, p.Name.Name)
+			}
+		}
+		enumType.Cases[c.Name.Name] = params
+		enumType.Constructors[c.Name.Name] = newEnumConstructor(enumType, c.Name.Name, params)
+	}
+	env.Set(enumType.Name, enumType)
+	return enumType, nil
+}
+
+func evalContractDeclaration(decl *ast.ContractDeclaration, env *Environment) (Value, error) {
+	if decl.Name == nil {
+		return nil, errors.New("contract declaration requires a name")
+	}
+	bodyEnv := NewEnclosedEnvironment(env)
+	if decl.Body != nil {
+		if _, err := evalBlock(decl.Body, bodyEnv); err != nil {
+			switch err.(type) {
+			case *returnSignal:
+				return nil, errors.New("return not allowed in contract body")
+			case *breakSignal, *continueSignal:
+				return nil, errors.New("loop control not allowed in contract body")
+			default:
+				return nil, err
+			}
+		}
+	}
+	contract := &Contract{Name: decl.Name.Name, Exports: cloneStore(bodyEnv.store)}
+	env.Set(contract.Name, contract)
+	return contract, nil
+}
+
+func instantiateStruct(structType *StructType, args []Value) (Value, error) {
+	if len(args) != len(structType.Fields) {
+		return nil, fmt.Errorf("expected %d arguments to %s, got %d", len(structType.Fields), structType.Name, len(args))
+	}
+	fields := make(map[string]Value, len(structType.Fields))
+	for i, name := range structType.Fields {
+		fields[name] = args[i]
+	}
+	instance := &StructInstance{Definition: structType, Fields: fields}
+	if init, ok := structType.Methods["init"]; ok {
+		if err := callInitializer(init, instance); err != nil {
+			return nil, err
+		}
+	}
+	return instance, nil
+}
+
+func instantiateClass(classType *ClassType, args []Value) (Value, error) {
+	if len(args) != len(classType.Fields) {
+		return nil, fmt.Errorf("expected %d arguments to %s, got %d", len(classType.Fields), classType.Name, len(args))
+	}
+	fields := make(map[string]Value, len(classType.Fields))
+	for i, name := range classType.Fields {
+		fields[name] = args[i]
+	}
+	instance := &ClassInstance{Definition: classType, Fields: fields}
+	if init, ok := classType.lookupMethod("init"); ok {
+		if err := callInitializer(init, instance); err != nil {
+			return nil, err
+		}
+	}
+	return instance, nil
+}
+
+func callInitializer(fn *Function, self Value) error {
+	bound := bindMethod(fn, self)
+	_, err := applyFunction(bound, []Value{})
+	return err
+}
+
+func newEnumConstructor(enum *EnumType, caseName string, params []string) Value {
+	return NewBuiltin(caseName, func(args []Value) (Value, error) {
+		if len(args) != len(params) {
+			return nil, fmt.Errorf("expected %d arguments to %s.%s, got %d", len(params), enum.Name, caseName, len(args))
+		}
+		fields := make(map[string]Value, len(params))
+		order := make([]string, len(params))
+		for i, name := range params {
+			fields[name] = args[i]
+			order[i] = name
+		}
+		return &EnumInstance{Enum: enum, Case: caseName, Fields: fields, Order: order}, nil
+	})
+}
+
+func enforceContract(block *ast.ContractBlock, env *Environment, result Value, fnName string) error {
+	if block == nil {
+		return nil
+	}
+	for _, clause := range block.Clauses {
+		clauseEnv := NewEnclosedEnvironment(env)
+		clauseEnv.Set("result", result)
+		guardSatisfied := true
+		if clause.Guard != nil {
+			guard, err := evalExpression(clause.Guard, clauseEnv)
+			if err != nil {
+				return err
+			}
+			guardSatisfied = isTruthy(guard)
+		}
+		if !guardSatisfied {
+			continue
+		}
+		condition, err := evalExpression(clause.Condition, clauseEnv)
+		if err != nil {
+			return err
+		}
+		if !isTruthy(condition) {
+			if fnName != "" {
+				return fmt.Errorf("contract violation in %s", fnName)
+			}
+			return errors.New("contract violation")
+		}
+	}
+	return nil
+}
+
+func applyFunction(fn Value, args []Value) (Value, error) {
+	switch callable := fn.(type) {
+	case *Function:
+		if callable.Builtin != nil {
+			return callable.Builtin(args)
+		}
+		if callable.Declaration == nil {
+			return nil, errors.New("function has no body")
+		}
+		if len(args) != len(callable.Declaration.Params) {
+			return nil, fmt.Errorf("expected %d arguments, got %d", len(callable.Declaration.Params), len(args))
+		}
+
+		callEnv := NewEnclosedEnvironment(callable.Env)
+		for i, param := range callable.Declaration.Params {
+			callEnv.Set(param.Name.Name, args[i])
+		}
+
+		var result Value = NullValue
+		var err error
+		if callable.Declaration.IsExprBody {
+			if callable.Declaration.BodyExpr != nil {
+				result, err = evalExpression(callable.Declaration.BodyExpr, callEnv)
+			}
+		} else if callable.Declaration.Body != nil {
+			result, err = evalBlock(callable.Declaration.Body, callEnv)
+			if err != nil {
+				switch sig := err.(type) {
+				case *returnSignal:
+					result = sig.value
+					err = nil
+				case *breakSignal:
+					err = errors.New("break outside of loop")
+				case *continueSignal:
+					err = errors.New("continue outside of loop")
+				}
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		if callable.Declaration.Contract != nil {
+			if err := enforceContract(callable.Declaration.Contract, callEnv, result, callable.Name); err != nil {
+				return nil, err
+			}
+		}
+		return result, nil
+	case *StructType:
+		return instantiateStruct(callable, args)
+	case *ClassType:
+		return instantiateClass(callable, args)
+	default:
+		return nil, fmt.Errorf("%s is not callable", fn.Type())
+	}
+}
+
+func builtinPrint(args []Value) (Value, error) {
+	parts := make([]string, len(args))
+	for i, arg := range args {
+		parts[i] = arg.Inspect()
+	}
+	fmt.Println(strings.Join(parts, " "))
+	return NullValue, nil
+}
+
+func builtinFormat(args []Value) (Value, error) {
+	if len(args) == 0 {
+		return nil, errors.New("format requires a template string")
+	}
+	tmpl, ok := args[0].(*String)
+	if !ok {
+		return nil, errors.New("format template must be a string")
+	}
+	var builder strings.Builder
+	argIndex := 1
+	for i := 0; i < len(tmpl.Value); i++ {
+		ch := tmpl.Value[i]
+		if ch == '{' {
+			if i+1 < len(tmpl.Value) && tmpl.Value[i+1] == '{' {
+				builder.WriteByte('{')
+				i++
+				continue
+			}
+			if i+1 < len(tmpl.Value) && tmpl.Value[i+1] == '}' {
+				if argIndex >= len(args) {
+					return nil, errors.New("not enough arguments for format string")
+				}
+				builder.WriteString(toString(args[argIndex]))
+				argIndex++
+				i++
+				continue
+			}
+		}
+		if ch == '}' && i+1 < len(tmpl.Value) && tmpl.Value[i+1] == '}' {
+			builder.WriteByte('}')
+			i++
+			continue
+		}
+		builder.WriteByte(ch)
+	}
+	return NewString(builder.String()), nil
+}
+
+func builtinSpawn(args []Value) (Value, error) {
+	if len(args) == 0 {
+		return nil, errors.New("spawn requires a function")
+	}
+	fn := args[0]
+	callArgs := args[1:]
+	task := NewTask()
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				task.deliver(NullValue, fmt.Errorf("panic: %v", r))
+			}
+		}()
+		result, err := applyFunction(fn, callArgs)
+		task.deliver(result, err)
+	}()
+	return task, nil
+}
+
+func builtinChannel(args []Value) (Value, error) {
+	capacity := 0
+	if len(args) > 0 {
+		num, ok := args[0].(*Number)
+		if !ok {
+			return nil, errors.New("channel capacity must be a number")
+		}
+		if num.Value < 0 {
+			return nil, errors.New("channel capacity must be non-negative")
+		}
+		if float64(int(num.Value)) != num.Value {
+			return nil, errors.New("channel capacity must be an integer")
+		}
+		capacity = int(num.Value)
+	}
+	return &ChannelValue{ch: make(chan Value, capacity), capacity: capacity}, nil
+}
+
+func renderStringLiteral(lit *ast.StringLiteral, env *Environment) (Value, error) {
+	raw := lit.Value
+	var builder strings.Builder
+	last := 0
+	for i := 0; i < len(raw); {
+		if raw[i] == '\\' {
+			i += 2
+			continue
+		}
+		if raw[i] == '$' && i+1 < len(raw) && raw[i+1] == '{' {
+			chunk := raw[last:i]
+			text, err := processStringChunk(chunk, lit.Raw)
+			if err != nil {
+				return nil, err
+			}
+			builder.WriteString(text)
+			end, placeholder, err := extractPlaceholder(raw, i+2)
+			if err != nil {
+				return nil, err
+			}
+			exprText, formatSpec := splitFormatPlaceholder(placeholder)
+			exprText = strings.TrimSpace(exprText)
+			formatSpec = strings.TrimSpace(formatSpec)
+			if exprText == "" {
+				return nil, errors.New("empty interpolation expression")
+			}
+			value, err := evaluateInlineExpression(exprText, env)
+			if err != nil {
+				return nil, err
+			}
+			segment, err := applyFormatSpec(value, formatSpec, lit.Format)
+			if err != nil {
+				return nil, err
+			}
+			builder.WriteString(segment)
+			last = end
+			i = end
+			continue
+		}
+		i++
+	}
+	if last < len(raw) {
+		chunk := raw[last:]
+		text, err := processStringChunk(chunk, lit.Raw)
+		if err != nil {
+			return nil, err
+		}
+		builder.WriteString(text)
+	}
+	return NewString(builder.String()), nil
+}
+
+func processStringChunk(chunk string, raw bool) (string, error) {
+	if chunk == "" {
+		return "", nil
+	}
+	if raw {
+		return strings.ReplaceAll(chunk, "\\$", "$"), nil
+	}
+	return decodeEscapes(chunk)
+}
+
+func decodeEscapes(input string) (string, error) {
+	var builder strings.Builder
+	for i := 0; i < len(input); i++ {
+		ch := input[i]
+		if ch != '\\' {
+			builder.WriteByte(ch)
+			continue
+		}
+		i++
+		if i >= len(input) {
+			return "", errors.New("unterminated escape sequence")
+		}
+		switch input[i] {
+		case 'n':
+			builder.WriteByte('\n')
+		case 'r':
+			builder.WriteByte('\r')
+		case 't':
+			builder.WriteByte('\t')
+		case '"':
+			builder.WriteByte('"')
+		case '\\':
+			builder.WriteByte('\\')
+		case '$':
+			builder.WriteByte('$')
+		default:
+			builder.WriteByte(input[i])
+		}
+	}
+	return builder.String(), nil
+}
+
+func extractPlaceholder(source string, start int) (int, string, error) {
+	depth := 1
+	for i := start; i < len(source); i++ {
+		ch := source[i]
+		if ch == '\\' {
+			i++
+			continue
+		}
+		if ch == '{' {
+			depth++
+			continue
+		}
+		if ch == '}' {
+			depth--
+			if depth == 0 {
+				return i + 1, source[start:i], nil
+			}
+		}
+	}
+	return 0, "", errors.New("unterminated interpolation expression")
+}
+
+func splitFormatPlaceholder(input string) (string, string) {
+	depth := 0
+	quote := byte(0)
+	for i := 0; i < len(input); i++ {
+		ch := input[i]
+		if ch == '\\' {
+			i++
+			continue
+		}
+		if ch == '"' || ch == '\'' {
+			if quote == 0 {
+				quote = ch
+			} else if quote == ch {
+				quote = 0
+			}
+			continue
+		}
+		if quote != 0 {
+			continue
+		}
+		switch ch {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		case ':':
+			if depth == 0 {
+				return input[:i], input[i+1:]
+			}
+		}
+	}
+	return input, ""
+}
+
+func evaluateInlineExpression(src string, env *Environment) (Value, error) {
+	lex := lexer.New(src)
+	p := parser.New(lex)
+	program := p.ParseProgram()
+	if len(p.Errors()) > 0 {
+		return nil, fmt.Errorf("failed to parse interpolation: %s", strings.Join(p.Errors(), "; "))
+	}
+	result := NullValue
+	for _, item := range program.Items {
+		stmt, ok := item.(ast.Statement)
+		if !ok {
+			return nil, fmt.Errorf("unsupported interpolation item %T", item)
+		}
+		val, err := evalStatement(stmt, env)
+		if err != nil {
+			return nil, err
+		}
+		result = val
+	}
+	return result, nil
+}
+
+func applyFormatSpec(val Value, spec string, allow bool) (string, error) {
+	if spec == "" {
+		return toString(val), nil
+	}
+	if !allow {
+		return "", errors.New("format specifiers require a format string literal")
+	}
+	switch spec {
+	case "upper":
+		return strings.ToUpper(toString(val)), nil
+	case "lower":
+		return strings.ToLower(toString(val)), nil
+	case "title":
+		return strings.Title(toString(val)), nil
+	case "trim":
+		return strings.TrimSpace(toString(val)), nil
+	default:
+		if strings.HasPrefix(spec, "%") {
+			return fmt.Sprintf(spec, valueToInterface(val)), nil
+		}
+		return "", fmt.Errorf("unknown format specifier %q", spec)
+	}
+}
+
+func valueToInterface(val Value) interface{} {
+	switch v := val.(type) {
+	case *Number:
+		return v.Value
+	case *String:
+		return v.Value
+	case *Boolean:
+		return v.Value
+	case *Null:
+		return nil
+	default:
+		return v.Inspect()
+	}
+}
+
+func implementsInterface(val Value, iface *InterfaceType) bool {
+	for name, arity := range iface.Methods {
+		prop, ok, err := getProperty(val, name)
+		if err != nil || !ok {
+			return false
+		}
+		fn, ok := prop.(*Function)
+		if !ok {
+			return false
+		}
+		if fn.Builtin == nil && fn.Declaration != nil {
+			if len(fn.Declaration.Params) != arity {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func evalIsOperator(left, right Value) (Value, error) {
+	switch typeVal := right.(type) {
+	case *InterfaceType:
+		return NewBoolean(implementsInterface(left, typeVal)), nil
+	case *ClassType:
+		return NewBoolean(isInstanceOfClass(left, typeVal)), nil
+	case *StructType:
+		inst, ok := left.(*StructInstance)
+		if !ok {
+			return NewBoolean(false), nil
+		}
+		return NewBoolean(inst.Definition == typeVal), nil
+	case *EnumType:
+		inst, ok := left.(*EnumInstance)
+		if !ok {
+			return NewBoolean(false), nil
+		}
+		return NewBoolean(inst.Enum == typeVal), nil
+	case *String:
+		return NewBoolean(left.Type() == typeVal.Value), nil
+	default:
+		return nil, fmt.Errorf("unsupported right-hand side for is operator: %s", right.Type())
+	}
+}
+
+func isInstanceOfClass(val Value, class *ClassType) bool {
+	inst, ok := val.(*ClassInstance)
+	if !ok {
+		return false
+	}
+	current := inst.Definition
+	for current != nil {
+		if current == class {
+			return true
+		}
+		current = current.Super
+	}
+	return false
+}
+
+func resolveCloser(val Value) (func() error, error) {
+	if closable, ok := val.(interface{ Close() error }); ok {
+		return func() error {
+			if err := closable.Close(); err != nil {
+				return wrapRuntimeError(err)
+			}
+			return nil
+		}, nil
+	}
+	prop, ok, err := getProperty(val, "close")
+	if err == nil && ok {
+		if fn, ok := prop.(*Function); ok {
+			return func() error {
+				_, err := applyFunction(fn, nil)
+				if err != nil {
+					return err
+				}
+				return nil
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("value of type %s is not closable", val.Type())
+}
+
+func evalUsingStatement(stmt *ast.UsingStatement, env *Environment) (Value, error) {
+	resource, err := evalExpression(stmt.Value, env)
+	if err != nil {
+		return nil, err
+	}
+	closer, err := resolveCloser(resource)
+	if err != nil {
+		return nil, err
+	}
+	blockEnv := NewEnclosedEnvironment(env)
+	if stmt.Name != nil {
+		blockEnv.Set(stmt.Name.Name, resource)
+	}
+	result, execErr := evalBlock(stmt.Body, blockEnv)
+	if closeErr := closer(); closeErr != nil {
+		if execErr == nil {
+			execErr = closeErr
+		}
+	}
+	if execErr != nil {
+		return result, execErr
+	}
+	return result, nil
+}
+
+func evalTryStatement(stmt *ast.TryStatement, env *Environment) (Value, error) {
+	tryEnv := NewEnclosedEnvironment(env)
+	result, err := evalBlock(stmt.Body, tryEnv)
+
+	switch err.(type) {
+	case *returnSignal, *breakSignal, *continueSignal:
+		if stmt.Finally != nil {
+			finalEnv := NewEnclosedEnvironment(env)
+			if finalResult, finalErr := evalBlock(stmt.Finally, finalEnv); finalErr != nil {
+				return finalResult, finalErr
+			}
+		}
+		return result, err
+	case nil:
+		// no error
+	default:
+		runtimeErr := wrapRuntimeError(err)
+		if stmt.Catch != nil {
+			catchEnv := NewEnclosedEnvironment(env)
+			if stmt.Catch.Identifier != nil {
+				catchEnv.Set(stmt.Catch.Identifier.Name, runtimeErr.value)
+			}
+			if stmt.Catch.Body != nil {
+				result, err = evalBlock(stmt.Catch.Body, catchEnv)
+			} else {
+				err = nil
+			}
+		} else {
+			err = runtimeErr
+		}
+	}
+
+	if stmt.Finally != nil {
+		finalEnv := NewEnclosedEnvironment(env)
+		finalResult, finalErr := evalBlock(stmt.Finally, finalEnv)
+		if finalErr != nil {
+			return finalResult, finalErr
+		}
+		if err == nil && finalResult != nil {
+			result = finalResult
+		}
+	}
+	return result, err
+}
+
+func evalConditionStatement(stmt *ast.ConditionStatement, env *Environment) (Value, error) {
+	for _, clause := range stmt.Clauses {
+		cond, err := evalExpression(clause.Test, env)
+		if err != nil {
+			return nil, err
+		}
+		if isTruthy(cond) {
+			clauseEnv := NewEnclosedEnvironment(env)
+			return evalStatement(clause.Body, clauseEnv)
+		}
+	}
+	if stmt.Else != nil {
+		elseEnv := NewEnclosedEnvironment(env)
+		return evalStatement(stmt.Else, elseEnv)
+	}
+	return NullValue, nil
+}

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -1,0 +1,164 @@
+package token
+
+import "fmt"
+
+// Type represents the type of lexical token.
+type Type string
+
+// Token represents a lexical token with positional metadata.
+type Token struct {
+	Type    Type
+	Literal string
+	Pos     Position
+	End     Position
+}
+
+// Position describes a location within a source file.
+type Position struct {
+	Offset int
+	Line   int
+	Column int
+}
+
+func (p Position) String() string {
+	return fmt.Sprintf("%d:%d", p.Line, p.Column)
+}
+
+const (
+	// Special tokens
+	ILLEGAL Type = "ILLEGAL"
+	EOF     Type = "EOF"
+
+	// Identifiers + literals
+	IDENT        Type = "IDENT"
+	NUMBER       Type = "NUMBER"
+	STRING       Type = "STRING"
+	FORMATSTRING Type = "FORMAT_STRING"
+	RAWSTRING    Type = "RAW_STRING"
+	TRUE         Type = "TRUE"
+	FALSE        Type = "FALSE"
+	NULL         Type = "NULL"
+
+	// Operators
+	ASSIGN         Type = "="
+	PLUS           Type = "+"
+	MINUS          Type = "-"
+	ASTERISK       Type = "*"
+	SLASH          Type = "/"
+	PERCENT        Type = "%"
+	PLUS_ASSIGN    Type = "+="
+	MINUS_ASSIGN   Type = "-="
+	STAR_ASSIGN    Type = "*="
+	SLASH_ASSIGN   Type = "/="
+	PERCENT_ASSIGN Type = "%="
+	BANG           Type = "!"
+	QUESTION       Type = "?"
+	COLON          Type = ":"
+	ELVIS          Type = "?:"
+	SAFE_DOT       Type = "?."
+	NON_NULL       Type = "!!"
+	AMPERSAND      Type = "&"
+	EQ             Type = "=="
+	NOT_EQ         Type = "!="
+	LT             Type = "<"
+	LTE            Type = "<="
+	GT             Type = ">"
+	GTE            Type = ">="
+	OR             Type = "||"
+	AND            Type = "&&"
+	ARROW          Type = "=>"
+	IS             Type = "is"
+	NOT_IS         Type = "!is"
+
+	// Delimiters
+	COMMA     Type = ","
+	DOT       Type = "."
+	SEMICOLON Type = ";"
+	LPAREN    Type = "("
+	RPAREN    Type = ")"
+	LBRACE    Type = "{"
+	RBRACE    Type = "}"
+	LBRACKET  Type = "["
+	RBRACKET  Type = "]"
+)
+
+const (
+	// Keywords
+	LET       Type = "let"
+	VAR       Type = "var"
+	FN        Type = "fn"
+	ASYNC     Type = "async"
+	CONTRACT  Type = "contract"
+	RETURNS   Type = "returns"
+	CLASS     Type = "class"
+	STRUCT    Type = "struct"
+	ENUM      Type = "enum"
+	MATCH     Type = "match"
+	MODULE    Type = "module"
+	IMPORT    Type = "import"
+	AS        Type = "as"
+	PACKAGE   Type = "package"
+	INTERFACE Type = "interface"
+	IF        Type = "if"
+	ELSE      Type = "else"
+	WHILE     Type = "while"
+	FOR       Type = "for"
+	RETURN    Type = "return"
+	BREAK     Type = "break"
+	CONTINUE  Type = "continue"
+	AWAIT     Type = "await"
+	TRY       Type = "try"
+	CATCH     Type = "catch"
+	FINALLY   Type = "finally"
+	THROW     Type = "throw"
+	USING     Type = "using"
+	EXT       Type = "ext"
+	CONDITION Type = "condition"
+	WHEN      Type = "when"
+)
+
+var keywords = map[string]Type{
+	"let":       LET,
+	"var":       VAR,
+	"fn":        FN,
+	"async":     ASYNC,
+	"contract":  CONTRACT,
+	"returns":   RETURNS,
+	"class":     CLASS,
+	"struct":    STRUCT,
+	"enum":      ENUM,
+	"match":     MATCH,
+	"module":    MODULE,
+	"import":    IMPORT,
+	"as":        AS,
+	"package":   PACKAGE,
+	"interface": INTERFACE,
+	"if":        IF,
+	"else":      ELSE,
+	"while":     WHILE,
+	"for":       FOR,
+	"return":    RETURN,
+	"break":     BREAK,
+	"continue":  CONTINUE,
+	"true":      TRUE,
+	"false":     FALSE,
+	"null":      NULL,
+	"is":        IS,
+	"await":     AWAIT,
+	"try":       TRY,
+	"catch":     CATCH,
+	"finally":   FINALLY,
+	"throw":     THROW,
+	"using":     USING,
+	"ext":       EXT,
+	"condition": CONDITION,
+	"when":      WHEN,
+}
+
+// LookupIdent identifies reserved keywords.
+func LookupIdent(ident string) Type {
+	if tok, ok := keywords[ident]; ok {
+		return tok
+	}
+	return IDENT
+}

--- a/selene.ebnf
+++ b/selene.ebnf
@@ -1,28 +1,151 @@
 (* ----------------- LEXICAL ----------------- *)
 
 identifier      = letter , { letter | digit | "_" } ;
-letter          = "A".."Z" | "a".."z" ;
+letter          = "A".."Z" | "a".."z" | "_" ;
 digit           = "0".."9" ;
 
-number          = digit , { digit } ;
-string          = '"' , { character - '"' } , '"' ;
+number          = digit , { digit } , [ "." , digit , { digit } ] ;
+string_literal  = '"' , { character - '"' } , '"' ;
+format_string   = "f\"" , { character - '"' } , '"' | "f\"\"\"" , { character } , "\"\"\"" ;
+raw_string      = "`" , { character - "`" } , "`" | "r\"" , { character - '"' } , '"'
+                | "r\"\"\"" , { character } , "\"\"\"" ;
 boolean         = "true" | "false" ;
 null            = "null" ;
 
-(* ----------------- TYPES ----------------- *)
+(* ----------------- PROGRAM STRUCTURE ----------------- *)
+
+program         = [ package_decl ] , { module_decl | statement } ;
+
+package_decl    = "package" , identifier , [ ";" ] ;
+
+module_decl     = "module" , identifier , [ block ] ;
+
+import_decl     = "import" , (
+                    identifier , string_literal , [ "as" , identifier ]
+                  | import_path , [ "as" , identifier ]
+                 ) , ";" ;
+
+import_path     = identifier , { "." , identifier } | string_literal ;
+
+(* ----------------- STATEMENTS ----------------- *)
+
+statement       = variable_decl
+                | function_decl
+                | extension_decl
+                | class_decl
+                | struct_decl
+                | enum_decl
+                | interface_decl
+                | contract_decl
+                | import_decl
+                | match_stmt
+                | if_stmt
+                | while_stmt
+                | for_stmt
+                | using_stmt
+                | try_stmt
+                | throw_stmt
+                | return_stmt
+                | break_stmt
+                | continue_stmt
+                | condition_stmt
+                | block
+                | expression , ";"
+                ;
+
+block           = "{" , { statement } , "}" ;
+
+variable_decl   = ("let" | "var") , identifier , [ ":" , type ] , "=" , expression , ";" ;
+
+(* ----------------- FUNCTIONS ----------------- *)
+
+function_decl   = "fn" , identifier , [ type_param_list ] ,
+                  "(" , [ param_list ] , ")" ,
+                  [ ":" , type ] ,
+                  [ "async" ] ,
+                  [ contract_block ] ,
+                  ( block | ("=" | "=>") , expression , [ ";" ] ) ;
+
+extension_decl  = "ext" , "fn" , type , "." , identifier ,
+                  [ type_param_list ] , "(" , [ param_list ] , ")" ,
+                  [ ":" , type ] ,
+                  [ "async" ] ,
+                  [ contract_block ] ,
+                  ( block | ("=" | "=>") , expression , [ ";" ] ) ;
+
+param_list      = param , { "," , param } ;
+param           = identifier , ":" , type ;
+
+type_param_list = "<" , identifier , { "," , identifier } , ">" ;
+
+contract_block  = "contract" , "{" , { contract_clause } , "}" ;
+contract_clause = "returns" , "(" , [ expression ] , ")" , "=>" , expression , ";" ;
+
+(* ----------------- TYPE ANNOTATIONS ----------------- *)
 
 type            = identifier , [ "<" , type , { "," , type } , ">" ] , [ "?" ] ;
-param           = identifier , ":" , type ;
-param_list      = [ param , { "," , param } ] ;
-type_param_list = identifier , { "," , identifier } ;
+
+(* ----------------- STRUCTURED DECLARATIONS ----------------- *)
+
+class_decl      = "class" , identifier , "(" , [ param_list ] , ")" ,
+                  [ ":" , identifier ] , [ block ] ;
+
+struct_decl     = "struct" , identifier , "(" , [ param_list ] , ")" , [ block ] ;
+
+enum_decl       = "enum" , identifier , [ type_param_list ] ,
+                  "{" , { enum_case } , "}" ;
+
+enum_case       = identifier , [ "(" , [ param_list ] , ")" ] , ";" ;
+
+interface_decl  = "interface" , identifier , "{" , { interface_member } , "}" ;
+interface_member= "fn" , identifier , "(" , [ param_list ] , ")" , [ ":" , type ] , ";" ;
+
+contract_decl   = "contract" , identifier , block ;
+
+(* ----------------- CONTROL FLOW ----------------- *)
+
+if_stmt         = "if" , expression , block , [ "else" , statement ] ;
+
+while_stmt      = "while" , expression , block ;
+
+for_stmt        = "for" , "(" , [ for_init ] , ";" , [ expression ] , ";" , [ expression ] , ")" , block ;
+for_init        = variable_binding | expression ;
+variable_binding= ("let" | "var") , identifier , [ ":" , type ] , "=" , expression ;
+
+using_stmt      = "using" , [ identifier , "=" ] , expression , block ;
+
+try_stmt        = "try" , block , [ catch_clause ] , [ finally_clause ] ;
+catch_clause    = "catch" , [ "(" , [ identifier ] , ")" ] , block ;
+finally_clause  = "finally" , block ;
+
+throw_stmt      = "throw" , expression , [ ";" ] ;
+return_stmt     = "return" , [ expression ] , [ ";" ] ;
+break_stmt      = "break" , [ ";" ] ;
+continue_stmt   = "continue" , [ ";" ] ;
+
+condition_stmt  = "condition" , "{" , { condition_clause } , [ condition_else ] , "}" ;
+condition_clause= "when" , expression , "=>" , block ;
+condition_else  = "else" , "=>" , block ;
+
+(* ----------------- MATCH ----------------- *)
+
+match_stmt      = "match" , expression , "{" , { pattern , "=>" , statement } , "}" ;
+
+pattern         = literal_pattern | identifier | struct_pattern | object_pattern ;
+
+literal_pattern = number | string_literal | format_string | raw_string | boolean | "null" ;
+
+struct_pattern  = identifier , "(" , [ pattern , { "," , pattern } ] , ")" ;
+object_pattern  = "{" , [ pair_pattern , { "," , pair_pattern } ] , "}" ;
+pair_pattern    = ( string_literal | identifier ) , ":" , pattern ;
 
 (* ----------------- EXPRESSIONS ----------------- *)
 
 expression      = assignment ;
 
-assignment      = conditional , [ "=" , expression ] ;
+assignment      = conditional , [ ( "=" | "+=" | "-=" | "*=" | "/=" | "%=" ) , expression ] ;
 
-conditional     = logical_or , [ "?:", expression ] ;           (* Elvis operator *)
+conditional     = logical_or , [ "?:" , expression ] ;
 
 logical_or      = logical_and , { "||" , logical_and } ;
 logical_and     = equality , { "&&" , equality } ;
@@ -33,19 +156,19 @@ comparison      = additive , { ("<" | "<=" | ">" | ">=" | "is" | "!is") , additi
 additive        = multiplicative , { ("+" | "-") , multiplicative } ;
 multiplicative  = unary , { ("*" | "/" | "%") , unary } ;
 
-unary           = [ "!" | "-" ] , unary | postfix ;
+unary           = ( "!" | "-" | "&" | "*" ) , unary | postfix ;
 
-postfix         = primary , { 
-                    ("." , identifier)                      (* member access *)
-                  | ("[" , expression , "]")                (* index access *)
-                  | ("?.", identifier)                      (* safe call *)
-                  | ("!!")                                   (* non-null assert *)
-                  | ("(" , [ argument_list ] , ")")         (* function call *)
+postfix         = primary , {
+                    "." , identifier
+                  | "[" , expression , "]"
+                  | "?." , identifier
+                  | "!!"
+                  | "(" , [ argument_list ] , ")"
                  } ;
 
 argument_list   = expression , { "," , expression } ;
 
-primary         = number | string | boolean | null
+primary         = number | string_literal | format_string | raw_string | boolean | "null"
                 | identifier
                 | array_literal
                 | object_literal
@@ -54,75 +177,6 @@ primary         = number | string | boolean | null
 
 array_literal   = "[" , [ expression , { "," , expression } ] , "]" ;
 object_literal  = "{" , [ pair , { "," , pair } ] , "}" ;
-pair            = ( string | identifier ) , ":" , expression ;
+pair            = ( string_literal | identifier ) , ":" , expression ;
 
 await_expr      = "await" , expression ;
-
-(* ----------------- STATEMENTS ----------------- *)
-
-statement       = variable_decl
-                | function_decl
-                | class_decl
-                | struct_decl
-                | enum_decl
-                | contract_decl
-                | import_decl
-                | match_stmt
-                | block
-                | expression , ";" ;
-
-block           = "{" , { statement } , "}" ;
-
-variable_decl   = ("let" | "var") , identifier , [ ":" , type ] , "=" , expression , ";" ;
-
-(* ----------------- FUNCTIONS ----------------- *)
-
-function_decl   = "fn" , identifier , [ "<" , type_param_list , ">" ] ,
-                  "(" , [ param_list ] , ")" ,
-                  [ ":" , type ] ,
-                  [ "async" ] ,
-                  [ contract_block ] ,
-                  ( block | "=" , expression , ";" ) ;
-
-contract_block  = "contract" , "{" , { contract_clause } , "}" ;
-contract_clause = "returns" , "(" , [ expression ] , ")" , "=>" , condition , ";" ;
-condition       = expression ;
-
-(* ----------------- CLASSES ----------------- *)
-
-class_decl      = "class" , identifier , "(" , [ param_list ] , ")" ,
-                  [ ":" , identifier ] ,                       (* inheritance/trait impl *)
-                  [ block ] ;
-
-(* ----------------- STRUCTS ----------------- *)
-
-struct_decl     = "struct" , identifier , "(" , [ param_list ] , ")" ,
-                  [ block ] ;
-
-(* ----------------- ENUMS ----------------- *)
-
-enum_decl       = "enum" , identifier , [ "<" , type_param_list , ">" ] ,
-                  "{" , { enum_case } , "}" ;
-
-enum_case       = identifier , [ "(" , [ param_list ] , ")" ] , ";" ;
-
-(* ----------------- MATCH ----------------- *)
-
-match_stmt      = "match" , expression , "{" ,
-                  { pattern , "=>", statement } ,
-                  "}" ;
-
-pattern         = literal_pattern | identifier_pattern | struct_pattern | object_pattern ;
-
-literal_pattern = number | string | boolean | "null" ;
-identifier_pattern = identifier ;
-struct_pattern  = identifier , "(" , [ pattern , { "," , pattern } ] , ")" ;
-object_pattern  = "{" , [ pair_pattern , { "," , pair_pattern } ] , "}" ;
-pair_pattern    = ( string | identifier ) , ":" , pattern ;
-
-(* ----------------- MODULES ----------------- *)
-
-program         = { module_decl | statement } ;
-
-module_decl     = "module" , identifier , "{" , { statement } , "}" ;
-import_decl     = "import" , identifier , { "." , identifier } , [ "as" , identifier ] , ";" ;

--- a/selene.lock
+++ b/selene.lock
@@ -1,0 +1,6 @@
+[[dependency]]
+module = "github.com/selene-lang/richmath"
+version = "v1.0.0"
+checksum = "sha256-42a29e0981b61735c644c8ab9947451b980ff3cc01217fb943a84a2f93c33079"
+vendor = "vendor/github.com/selene-lang/richmath@v1.0.0"
+

--- a/selene.toml
+++ b/selene.toml
@@ -1,0 +1,14 @@
+[project]
+name = "selenelang"
+version = "0.9.0"
+module = "github.com/selene-lang/selenelang"
+entry = "cmd/selene"
+
+[docs]
+paths = ["docs", "README.md"]
+
+[examples]
+roots = ["examples"]
+
+[dependencies]
+"github.com/selene-lang/richmath" = { version = "v1.0.0", source = "https://github.com/selene-lang/richmath" }

--- a/vendor/github.com/selene-lang/richmath@v1.0.0/series.selene
+++ b/vendor/github.com/selene-lang/richmath@v1.0.0/series.selene
@@ -1,0 +1,26 @@
+package richmath;
+
+fn sum(values: Array): Number {
+    var total = 0;
+    for (let i = 0; i < values.length; i += 1) {
+        total += values[i];
+    }
+    return total;
+}
+
+fn average(values: Array): Number {
+    if values.length == 0 {
+        return 0;
+    }
+    return sum(values) / values.length;
+}
+
+module stats {
+    fn runningMean(values: Array): Number {
+        var rolling = 0;
+        for (let i = 0; i < values.length; i += 1) {
+            rolling += (values[i] - rolling) / (i + 1);
+        }
+        return rolling;
+    }
+}


### PR DESCRIPTION
## Summary
- overhaul the Selene CLI with explicit `run`, `tokens`, `init`, and `deps` workflows that load vendored dependencies before executing scripts【F:cmd/selene/main.go†L20-L423】
- introduce project utilities for reading and writing `selene.toml`/`selene.lock`, vendoring sources with SHA-256 checks, and shipping a sample dependency under `vendor/`【F:internal/project/manifest.go†L24-L397】【F:internal/project/deps.go†L10-L44】【F:internal/project/fs.go†L15-L147】【F:selene.lock†L1-L5】【F:vendor/github.com/selene-lang/richmath@v1.0.0/series.selene†L1-L26】
- expose runtime helpers for module construction/environment snapshots and refresh the ANTLR/EBNF grammars to cover the expanded language surface【F:internal/runtime/runtime.go†L140-L166】【F:internal/runtime/runtime.go†L474-L511】【F:ModernLang.g4†L5-L159】【F:selene.ebnf†L1-L182】
- document the dependency workflow and add a `dependency` example that imports the vendored `github.com/selene-lang/richmath` module【F:README.md†L7-L114】【F:docs/getting-started.md†L45-L102】【F:docs/examples.md†L250-L310】【F:examples/dependency.selene†L1-L16】

## Testing
- go build ./...【97721b†L1】
- go run ./cmd/selene deps verify【2e4389†L1-L3】
- go run ./cmd/selene run examples/dependency.selene【82845d†L1-L5】

------
https://chatgpt.com/codex/tasks/task_e_68df75d68af8832eb5df58e1ac665c75