### PR TITLE
Fix safe uint32 conversion to satisfy gosec G115

### DIFF
--- a/internal/lsp/highlight.go
+++ b/internal/lsp/highlight.go
@@ -29,10 +29,11 @@ func safeUint32(value int) (uint32, bool) {
 	if value < 0 {
 		return 0, false
 	}
-	if uint64(value) > maxUint32 {
+	converted := uint64(value)
+	if converted > maxUint32 {
 		return 0, false
 	}
-	return uint32(value), true
+	return uint32(converted), true
 }
 
 // NewHighlighter constructs a semantic token highlighter with Selene token types.


### PR DESCRIPTION
## Summary
- ensure the LSP highlighter's safeUint32 helper converts via a uint64 intermediary before casting back to uint32 to avoid overflow

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e26365caf4832ea82e0219b79664d9