### PR TITLE
Add release automation for prebuilt Selene installers

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,95 @@
+name: Selene CLI Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            archive_extension: tar.gz
+            binary_extension: ''
+          - goos: linux
+            goarch: arm64
+            archive_extension: tar.gz
+            binary_extension: ''
+          - goos: darwin
+            goarch: amd64
+            archive_extension: tar.gz
+            binary_extension: ''
+          - goos: darwin
+            goarch: arm64
+            archive_extension: tar.gz
+            binary_extension: ''
+          - goos: windows
+            goarch: amd64
+            archive_extension: zip
+            binary_extension: .exe
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build CLI binary
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          go build -o build/selene${{ matrix.binary_extension }} ./cmd/selene
+
+      - name: Package archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="selene-${{ matrix.goos }}-${{ matrix.goarch }}"
+          staging="dist/$archive"
+          mkdir -p "$staging"
+          cp build/selene${{ matrix.binary_extension }} "$staging/"
+          cp LICENSE "$staging/"
+          if [ "${{ matrix.archive_extension }}" = "zip" ]; then
+            (cd dist && zip -r "$archive.zip" "$archive")
+          else
+            (cd dist && tar -czf "$archive.tar.gz" "$archive")
+          fi
+          rm -rf "$staging"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: selene-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/selene-${{ matrix.goos }}-${{ matrix.goarch }}.${{ matrix.archive_extension }}
+
+  publish:
+    name: Publish Release Assets
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release
+          pattern: selene-*
+          merge-multiple: true
+
+      - name: List release assets
+        run: ls -R release
+
+      - name: Publish GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release/*

--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ Selene is an experimental programming-language frontend written in Go. It packag
 
 > 🚀 **Launch checklist:** Go 1.25.1+, a POSIX shell, and curiosity.
 
+### Download a release build
+
+Prebuilt archives live on the [GitHub Releases](https://github.com/cybellereaper/selenelang/releases) page for Linux, macOS, and Windows.
+Grab the archive that matches your platform, unpack it, and place the `selene` (or `selene.exe`) binary somewhere on your `PATH`:
+
+```bash
+# Linux / macOS
+tar -xzf selene-linux-amd64.tar.gz
+sudo install selene-linux-amd64/selene /usr/local/bin/selene
+
+# Windows (PowerShell)
+Expand-Archive selene-windows-amd64.zip
+Move-Item selene-windows-amd64\selene.exe "C:\\Program Files\\Selene\\selene.exe"
+```
+
+### Build from source
+
 ```bash
 git clone https://github.com/cybellereaper/selenelang.git
 cd selenelang
@@ -42,7 +59,7 @@ go build ./...
 go install ./cmd/selene
 ```
 
-Fire up the CLI to verify the install:
+Fire up the CLI to verify either install path:
 
 ```bash
 selene --help

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -12,9 +12,15 @@ Welcome to the Selene launchpad! This guide walks through installing the toolcha
 - [Go 1.21+](https://go.dev/dl/) for building the CLI and embedding Selene.
 - A terminal with access to standard developer tools.
 
+## Grab a release build
+
+The quickest path is to download a prebuilt archive from the [GitHub Releases](https://github.com/cybellereaper/selenelang/releases) page.
+Each asset bundles the CLI binary and license for Linux, macOS, and Windows.
+Unpack the archive that matches your platform and move the `selene` (or `selene.exe`) binary somewhere on your `PATH`.
+
 ## Fetch the source
 
-Clone the repository and download dependencies:
+Prefer to build it yourself or hack on the language? Clone the repository and download dependencies:
 
 ```bash
 git clone https://github.com/your-user/selenelang.git


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that cross-compiles Selene for Linux, macOS, and Windows and uploads the archives to tagged releases
- document the new release artifacts in the README quick launch section and the getting started guide

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e279365538832e9cf2c90737defb66